### PR TITLE
Add detailed security analysis notes for the password manager

### DIFF
--- a/security_notes/SUMMARY.md
+++ b/security_notes/SUMMARY.md
@@ -1,0 +1,45 @@
+# Chromium Password Management: End-to-End Security Analysis Summary
+
+This document summarizes a comprehensive security analysis of the Chromium password management and leak detection systems. The analysis covered the entire lifecycle of a credential, from being saved and filled to being checked for compromises, and how those results are presented to the user. Detailed notes for each component can be found in the corresponding markdown files in this directory.
+
+## System Architecture & Security Principles
+
+The Chromium password management system is a mature, complex, and robustly designed piece of security-critical infrastructure. Its architecture is built on several key principles that are consistently enforced across the stack:
+
+1.  **Strict Separation of Concerns**: Each class has a well-defined responsibility. The `PasswordStore` only handles storage, the `PasswordFormManager` manages the state of a single form, the `LeakDetectionCheck` performs a single cryptographic check, and the `PasswordCheckDelegate` handles UI logic. This separation minimizes the chance that a bug in one component will have cascading security failures in another.
+
+2.  **Thread-Safety and Asynchronous Operations**: All disk I/O and expensive computations (like cryptography) are performed on background threads, with results safely posted back to the UI thread via callbacks. This prevents UI jank and reduces the likelihood of race conditions.
+
+3.  **Privacy-Preserving Cryptography**: The leak detection feature is a model for privacy-preserving design. The use of a blinded, client-keyed cryptographic protocol ensures that Google's servers can never learn a user's plaintext password, nor can they determine the final result of a leak check. This protects user privacy even from the service provider.
+
+4.  **Secure UI Bridging**: The `passwordsPrivate` API provides a secure bridge between the privileged browser process and the less-privileged WebUI renderer. It follows two critical patterns:
+    *   **Data Sanitization**: No sensitive data (especially plaintext passwords) is ever sent to the renderer.
+    *   **Opaque IDs**: The UI acts upon opaque integer IDs provided by the backend, preventing it from crafting malicious requests with arbitrary data.
+
+5.  **User-Gated Sensitive Operations**: For highly sensitive actions like password export or import conflict resolution, the system does not proceed automatically. It forces a user interaction step, often combined with mandatory OS-level re-authentication. This ensures that a user is aware of and explicitly consents to actions that could expose their data or modify their existing credential store.
+
+6.  **Robust Provisional Saving**: For features like password generation, the system uses a "presave-then-commit" pattern. A provisional entry is created in the database immediately, ensuring data isn't lost if the user navigates away. This entry is only made permanent after the user successfully completes the entire flow (e.g., form submission). This two-phase commit strategy adds robustness against data loss.
+
+7.  **Unified Data Presentation**: Components like `SavedPasswordsPresenter` and `PasswordsGrouper` create a vital abstraction layer. They take raw data from multiple, disparate sources (profile store, account store, passkeys, affiliation data) and synthesize it into a single, unified `CredentialUIEntry` model for the rest of the UI to consume. This hides the complexity of the underlying storage from the UI logic and ensures a consistent presentation to the user.
+
+## Key Areas of Security Risk & Complexity
+
+While the system is well-designed, its complexity means that potential risks are concentrated in specific, highly-complex areas:
+
+*   **`PasswordFormManager`**: This class is the most complex component analyzed. Its management of "username-first" flows, where a username from one page is associated with a password on another, is a particularly large and sensitive attack surface. A logic error in its state machine or its eTLD+1 matching could lead to incorrect credential association.
+
+*   **Generation Conflict Resolution (`PasswordGenerationManager`)**: The logic to handle cases where a generated password might overwrite an existing credential is a critical security control. It correctly detects username conflicts and forces a user confirmation via a separate UI prompt. A bug in this conflict detection could lead to accidental data loss for a user's existing account.
+
+*   **Import/Export Data Handling (`PasswordManagerPorter`)**: The export feature creates a plaintext CSV file of all passwords, the security of which becomes the user's responsibility. The import feature must safely parse a potentially untrusted CSV file and correctly handle conflicts with existing data. A bug in the parser or the conflict resolution logic could lead to data corruption or loss.
+
+*   **Trust in Affiliation Data (`PasswordsGrouper`)**: The user-facing grouping of credentials (e.g., combining `google.com` and `youtube.com`) is entirely dependent on the data provided by the external `AffiliationService`. The security of this grouping relies on the assumption that this service provides accurate, non-malicious data. An error or compromise in the affiliation data could cause unrelated sites to be grouped together, potentially misleading the user.
+
+*   **`FormDataParser`**: The security of both filling and saving credentials fundamentally relies on the correct classification of form fields. While it uses a combination of local heuristics and server-side predictions, a mis-classification (e.g., mistaking a security question for a password) could lead to incorrect data being saved or filled.
+
+*   **Cryptographic Implementation (`leak_detection_request_utils.cc`)**: The privacy of the leak detection feature rests entirely on the correctness of the cryptographic protocol implemented in this file. While the high-level design is sound, any low-level bug in the implementation of the hashing or encryption could undermine its privacy guarantees.
+
+*   **State Synchronization**: The entire system relies on a complex web of asynchronous callbacks and state updates between multiple components (`BulkLeakCheckService`, `PasswordCheckDelegate`, `InsecureCredentialsManager`, etc.). A bug in the order of these operations or a failure to correctly handle a state transition could lead to the UI showing stale or incorrect information, potentially eroding user trust (e.g., a fixed password still showing as leaked).
+
+## Conclusion
+
+The Chromium password management system is a prime example of defense-in-depth for a security-critical feature. It employs strong architectural patterns, isolates responsibilities, and uses state-of-the-art, privacy-preserving techniques. The most significant risks lie not in broad architectural flaws, but in the implementation details of its most complex components, where the interaction of multiple signals and asynchronous states creates a challenging environment to maintain. Future security reviews should continue to focus on these high-complexity areas.

--- a/security_notes/insecure_credentials_manager.md
+++ b/security_notes/insecure_credentials_manager.md
@@ -1,0 +1,48 @@
+# InsecureCredentialsManager (`components/password_manager/core/browser/ui/insecure_credentials_manager.cc`)
+
+## 1. Summary
+
+The `InsecureCredentialsManager` is a crucial component that acts as the source of truth for the state of all insecure credentials within a profile. It is responsible for three main tasks:
+1.  Persisting the results of server-side security checks (i.e., saving the fact that a credential is leaked or phished).
+2.  Triggering and caching the results of expensive client-side security checks (i.e., identifying weak and reused passwords).
+3.  Synthesizing these different issue types into a single, comprehensive list of insecure credentials for consumption by UI components like the Password Checkup page.
+
+It sits between the `SavedPasswordsPresenter` (which provides the raw list of saved passwords) and UI-facing handlers (like `PasswordCheckDelegate`), abstracting away the complexity of how insecurity is determined and stored.
+
+## 2. Architecture: A Caching and Synthesizing Layer
+
+The manager's design is that of a smart cache and data synthesizer. It doesn't have its own persistent storage, but rather orchestrates the storage of insecurity information in the `PasswordStore` and caches the results of local computations.
+
+*   **Data Source**: The manager's ground truth is the `SavedPasswordsPresenter`, which it observes for any changes to the user's saved passwords.
+
+*   **Asynchronous Checks**: For performance, the expensive checks for weak and reused passwords are not run on the UI thread.
+    *   `StartWeakCheck` and `StartReuseCheck` post a task to a background thread pool.
+    *   The heavy lifting is done by the `BulkWeakCheck` and `BulkReuseCheck` functions, which operate on the provided list of credentials.
+    *   The results (sets of weak or reused passwords) are returned to the UI thread and stored in the `weak_passwords_` and `reused_passwords_` member variables, which act as a cache.
+
+*   **Persisting Leaked Credentials**: The `SaveInsecureCredential` method is the key entry point for making leak information permanent. It takes a leaked credential, finds the corresponding saved entry in the `SavedPasswordsPresenter`, and updates its `password_issues` map. This change is then sent back through the presenter to the `PasswordStore`, where it is written to the database.
+
+*   **Synthesizing Results**: The main getter, `GetInsecureCredentialEntries`, dynamically creates the list of insecure credentials. It iterates through all passwords from the presenter and, for each one, combines the persisted issues (like `kLeaked` from the `PasswordForm` itself) with the cached, locally-computed issues (by checking if the password is in `weak_passwords_` or `reused_passwords_`).
+
+## 3. Security-Critical Logic
+
+The security of the Password Checkup feature relies heavily on the correctness of this manager's logic.
+
+*   **`SaveInsecureCredential`**: This is the most critical function. It is responsible for permanently flagging a credential as leaked.
+    *   **Matching Logic**: It correctly uses `CanonicalizeUsername` to match the incoming leaked credential against the stored credentials. This is vital to ensure that variations in username capitalization or domain (e.g., `gmail.com` vs `googlemail.com`) don't cause a leak to be missed.
+    *   **Modification**: It directly modifies the `password_issues` map of the `CredentialUIEntry` before calling `presenter_->EditSavedCredentials()`. A bug here, such as modifying the wrong field or using the wrong `InsecureType`, would break the feature.
+
+*   **`MuteCredential` / `UnmuteCredential`**: These methods modify the `is_muted` flag within the `password_issues` map for a given credential.
+    *   **Targeted Logic**: The logic correctly uses a `SupportsMuteOperation` check to ensure that only server-verifiable issues (`kLeaked`, `kPhished`) can be muted. Client-side issues like `kWeak` cannot be muted, which is the intended behavior.
+    *   **Integrity**: Like saving, this relies on the `EditSavedCredentials` flow to persist the state change, ensuring the data remains consistent in the `PasswordStore`.
+
+*   **`OnSavedPasswordsChanged`**: This observer method is critical for data consistency.
+    *   When passwords are changed, it intelligently triggers new weak and reuse checks *only* for the affected credentials, rather than re-running the entire expensive check. This is both a performance optimization and a correctness feature, ensuring the cached data doesn't become stale.
+    *   A failure to correctly identify which changes require a re-check could lead to the UI showing outdated insecurity information.
+
+## 4. Related Components
+
+*   `components/password_manager/core/browser/ui/saved_passwords_presenter.h`: The source of truth for all saved passwords. The manager is tightly coupled with it.
+*   `components/password_manager/core/browser/password_store.h`: The ultimate destination for the `password_issues` data that this manager modifies.
+*   `chrome/browser/extensions/api/passwords_private/password_check_delegate.h`: The primary client of this class, which uses it to drive the Password Checkup UI.
+*   `components/password_manager/core/browser/ui/reuse_check_utility.h` & `weak_check_utility.h`: These files contain the actual logic for identifying reused and weak passwords, respectively, which is run on the background thread.

--- a/security_notes/password_autofill_manager.md
+++ b/security_notes/password_autofill_manager.md
@@ -1,0 +1,41 @@
+# PasswordAutofillManager (`components/password_manager/core/browser/password_autofill_manager.cc`)
+
+## 1. Summary
+
+The `PasswordAutofillManager` is the component that directly controls the password autofill UI, acting as the crucial bridge between the password data model and the user-facing suggestion dropdown. While `PasswordFormManager` decides *if* and *what* to save, `PasswordAutofillManager` decides *what* to show for filling and *how* to react when the user selects a suggestion. It implements the `autofill::AutofillSuggestionDelegate` interface, making it the designated handler for all password-related actions originating from the Autofill UI.
+
+## 2. Architecture: The UI Delegate
+
+The `PasswordAutofillManager` is owned by a `PasswordManagerDriver` and lives for the duration of a frame. Its primary role is to respond to UI triggers and manage the suggestion popup lifecycle.
+
+1.  **Receiving Data**: Its main entry point is `OnAddPasswordFillData`, which is called by a `PasswordFormManager` after it has fetched credentials from the `PasswordStore`. The `PasswordAutofillManager` stores this data in its `fill_data_` member, which contains all the potential credentials for the current context.
+
+2.  **Generating Suggestions**: When triggered (e.g., by a field focus or a manual request), it calls its internal `PasswordSuggestionGenerator` (`suggestion_generator_`). This helper class is responsible for creating the list of `autofill::Suggestion` objects, turning the raw `PasswordForm` data into user-displayable entries, including usernames, password hints, favicons, and special entries like "Manage passwords...".
+
+3.  **Showing UI**: It uses the `autofill::AutofillClient` interface to show, hide, and update the suggestion popup, passing it the list of `Suggestion` objects.
+
+4.  **Handling User Actions**: Its most critical role is handling user selections via the `DidAcceptSuggestion` method.
+
+## 3. Security-Critical Logic & Attack Surface
+
+The `PasswordAutofillManager`'s primary security responsibility is to ensure that the user's explicit selection from the UI is translated into the correct action, with all necessary security checks performed.
+
+*   **`DidAcceptSuggestion` - The Central Hub**: This large `switch` statement is the heart of the class's security model. A bug here could have severe consequences.
+    *   **Credential Selection**: It must correctly map the chosen `Suggestion` back to the correct `PasswordForm` in its `fill_data_`. An off-by-one error or a key mismatch in `GetPasswordAndMetadataForUsername` could cause the wrong password to be filled.
+    *   **Cross-Domain Confirmation**: When a user selects a credential for an affiliated domain (`is_grouped_affiliation`), this method is responsible for triggering a confirmation popup via `cross_domain_confirmation_controller_`. This is a critical defense-in-depth measure to prevent a user from being tricked into sending a credential for `google.com` to `google.evil.com`. Bypassing this check would be a high-severity vulnerability.
+    *   **Biometric Re-authentication**: On platforms that require it, `OnPasswordCredentialSuggestionAccepted` is responsible for triggering a device re-authentication flow via the `DeviceAuthenticator`. This is a fundamental security gate for accessing stored credentials, and any logic error that bypasses it would be critical.
+    *   **WebAuthn & Special Flows**: It correctly delegates non-password suggestion types (like WebAuthn credentials or "Trouble signing in?") to their specialized handlers (`WebAuthnCredentialsDelegate`, `UndoPasswordChangeController`), ensuring these complex flows are handled by the right component.
+
+*   **State Management and Data Lifetime**:
+    *   **`fill_data_`**: This member holds the `PasswordFormFillData`, which includes usernames and passwords for the current context. It is paramount that this data is cleared when the user navigates away from the page. The `DidNavigateMainFrame` method correctly resets `fill_data_`, preventing credentials from one site from being available on another.
+    *   **Previewing (`PreviewSuggestion`)**: The manager must ensure that previewing a credential does not leak the password value to a malicious page's script. It relies on the `PasswordManagerDriver` to handle the preview in a secure way that is isolated from the page's DOM.
+
+*   **Manual Fallback Flow**: The class manages a `PasswordManualFallbackFlow` for handling manual triggers (e.g., from the context menu). This represents a separate, parallel attack surface for filling credentials that must be as secure as the primary suggestion-based flow.
+
+## 4. Related Components
+
+*   `components/password_manager/core/browser/password_suggestion_generator.cc`: A helper class that contains the business logic for creating the list of `autofill::Suggestion` objects from the available password data.
+*   `components/password_manager/core/browser/password_manager_driver.h`: The interface to the renderer, used to execute the actual fill operations.
+*   `components/autofill/core/browser/foundations/autofill_client.h`: The browser-level interface for controlling the Autofill UI popup.
+*   `components/device_reauth/device_authenticator.h`: The platform-specific interface for triggering biometric or OS-level re-authentication.
+*   `components/password_manager/core/browser/webauthn_credentials_delegate.h`: The handler for all WebAuthn-related UI and actions.

--- a/security_notes/password_bulk_leak_check.md
+++ b/security_notes/password_bulk_leak_check.md
@@ -1,0 +1,61 @@
+# Password Bulk Leak Check (`components/password_manager/core/browser/leak_detection/bulk_leak_check_service.cc`)
+
+## 1. Summary
+
+The `BulkLeakCheckService` is the central, profile-specific (`KeyedService`) orchestrator for the Password Checkup feature. Its purpose is to manage the process of checking a large volume of saved passwords against the leak database in a controlled and observable manner. It acts as a state machine and a delegation point, but does not perform any cryptographic operations or network requests itself. Instead, it creates and manages a `BulkLeakCheck` object, which is responsible for the actual work.
+
+## 2. Architecture: A State-Driven Orchestrator
+
+The service's architecture is designed to manage a potentially long-running and resource-intensive operation while providing clear state updates to its clients (primarily the Password Checkup UI).
+
+1.  **Initiation**: The process begins when a client calls `CheckUsernamePasswordPairs`, providing a list of `LeakCheckCredential` objects.
+
+2.  **State Management**: The service immediately transitions its internal state to `kRunning` and notifies its observers. It maintains a simple but crucial state machine with states like `kIdle`, `kRunning`, `kCanceled`, and various error states (`kSignedOut`, `kNetworkError`, etc.).
+
+3.  **Delegation to `BulkLeakCheck`**: The service's primary action is to create a `BulkLeakCheck` object (via `LeakDetectionCheckFactoryImpl`). This `BulkLeakCheck` object is the true worker: it takes the list of credentials and is responsible for iterating through them, creating a `LeakDetectionCheck` for each one, and executing the check. If a check is already in progress when `CheckUsernamePasswordPairs` is called again, the new credentials are simply appended to the queue of the existing `BulkLeakCheck` instance.
+
+4.  **Asynchronous Results**: The `BulkLeakCheckService` implements the `BulkLeakCheckDelegateInterface`. The `BulkLeakCheck` object reports its progress back to the service through this interface:
+    *   `OnFinishedCredential`: This callback is invoked for each credential as its check completes, providing the result (`IsLeaked`). The service then forwards this result to its own observers.
+    *   `OnError`: If a fatal error occurs during the process (e.g., network failure, authentication token couldn't be obtained), this method is called. The service translates the specific `LeakDetectionError` into the appropriate public state and terminates the check.
+
+5.  **Completion**: When the `BulkLeakCheck` has processed all its credentials (i.e., `GetPendingChecksCount()` returns 0), the `BulkLeakCheckService` transitions its state back to `kIdle`, cleans up the `bulk_leak_check_` object, and notifies observers that the process is complete.
+
+## 3. Security Considerations
+
+The security posture of `BulkLeakCheckService` is primarily about **correct orchestration and state management**, rather than direct data handling.
+
+*   **Reliance on `LeakDetectionCheck`**: The service's security and privacy guarantees are entirely inherited from the underlying `LeakDetectionCheck` component. It trusts that each individual check is performed using the privacy-preserving cryptographic protocol. The `BulkLeakCheckService` itself never handles plaintext passwords; it only marshals `LeakCheckCredential` objects to the worker class.
+
+*   **State Integrity**: The most critical security responsibility of this class is maintaining the integrity of its state machine. A bug that caused the state to be reported incorrectly could confuse the user or UI logic. For example, if it reported `kIdle` prematurely, the user might believe their check was complete when it was not. The implementation correctly handles transitions upon start, completion, cancellation (`Cancel` method), and errors.
+
+*   **Resource Management**: The service correctly owns and manages the lifecycle of the `bulk_leak_check_` object. The `Cancel` and `Shutdown` methods ensure that the underlying check is stopped and resources are released, preventing orphaned processes or use-after-free conditions.
+
+*   **Error Propagation**: It correctly translates low-level `LeakDetectionError` types into high-level service states. This ensures that a critical failure (like `kTokenRequestFailure`) is not silently ignored but is instead propagated to the UI layer, which can then prompt the user appropriately.
+
+## 4. The Worker: `BulkLeakCheckImpl`
+
+The `BulkLeakCheckImpl` class is the concrete implementation of the `BulkLeakCheck` interface and acts as the true "worker" for the bulk check process. It receives the list of credentials from the service and manages their journey through the leak check pipeline.
+
+*   **Pipeline Architecture**: The class's core design is a set of queues that represent the stages of the leak check process for a credential. This architecture serves as a natural throttling mechanism, preventing an overwhelming number of concurrent operations. The queues are:
+    1.  `waiting_encryption_`: Credentials that have been received but are waiting for their cryptographic payload to be computed on a background thread.
+    2.  `waiting_token_`: Credentials that have a payload but are waiting for an OAuth2 access token.
+    3.  `waiting_response_`: Credentials with a payload and token that are waiting for a response from the leak detection API.
+    4.  `waiting_decryption_`: Credentials that have a server response and are waiting for the final client-side analysis.
+
+*   **Processing Flow**:
+    1.  When `CheckCredentials` is called, all credentials are put into the `waiting_encryption_` queue, and a task is posted to a background thread to compute the payload for each one using `PrepareSingleLeakRequestData`. A single, secret `encryption_key_` is generated once for the entire lifetime of the `BulkLeakCheckImpl` object and is used for all credentials in the batch.
+    2.  As each payload is prepared, the corresponding credential moves to the `waiting_token_` queue, and an access token request is immediately fired.
+    3.  When a token is received, the credential moves to `waiting_response_`, and the `LeakDetectionRequest` is sent.
+    4.  When the network response arrives, the credential moves to `waiting_decryption_` for the final `AnalyzeResponse` step.
+    5.  Once the analysis is complete, the final result is reported to the delegate (`BulkLeakCheckService`), and the credential is removed from the pipeline.
+
+*   **Security & Robustness**:
+    *   **Throttling**: This pipeline design is inherently self-throttling. The number of concurrent network requests is limited by the speed of the preceding cryptographic and token-request steps.
+    *   **Fail-Fast Error Handling**: If any step in the pipeline fails for a given credential (e.g., token request fails, network error), the entire bulk check is aborted by calling `delegate_->OnError()`. This is a robust design that prevents the system from continuing in a partially failed state.
+    *   **Separation of Concerns**: The class correctly delegates the sensitive cryptographic work to `PrepareSingleLeakRequestData` and `AnalyzeResponse`, focusing its own logic on state management and flow control.
+
+## 5. Related Components
+
+*   `components/password_manager/core/browser/leak_detection/bulk_leak_check_service.h`: The owner and public-facing interface for the bulk leak check feature.
+*   `components/password_manager/core/browser/leak_detection/leak_detection_check_factory_impl.h`: The factory used to instantiate the `BulkLeakCheckImpl` object.
+*   `chrome/browser/ui/webui/settings/password_check_handler.h`: A likely client of this service, responsible for bridging the gap between the C++ backend and the `chrome://settings` UI.

--- a/security_notes/password_checkup_ui.md
+++ b/security_notes/password_checkup_ui.md
@@ -1,0 +1,67 @@
+# Password Checkup UI (`chrome/browser/extensions/api/passwords_private/password_check_delegate.cc`)
+
+## 1. Summary
+
+The `PasswordCheckDelegate` is the C++ backend and central controller for the Password Checkup feature within the `chrome://settings` page. It lives in the browser process and serves as the bridge between the high-level WebUI and the underlying password management services. It is responsible for handling all user-facing logic, such as starting a check, querying for insecure credentials, muting and unmuting alerts, and reporting the progress of a running check back to the UI. It translates the complex, asynchronous state of the backend services into a simplified model that the UI can easily consume.
+
+## 2. Architecture: The `passwordsPrivate` API Backend
+
+The `PasswordCheckDelegate` is a key part of the `passwordsPrivate` extension API, which is the mechanism used to expose browser-level password functionality to the semi-privileged settings WebUI.
+
+1.  **Initialization**: The delegate is created along with the `PasswordsPrivateAPI` and immediately begins observing the core password services:
+    *   `SavedPasswordsPresenter`: To get the list of all saved passwords.
+    *   `InsecureCredentialsManager`: To get lists of credentials that have already been identified as weak, reused, or leaked.
+    *   `BulkLeakCheckService`: To receive state updates about an ongoing bulk leak check.
+
+2.  **Handling UI Requests**: The delegate's public methods correspond directly to actions a user can take on the settings page. When the JavaScript frontend calls `chrome.passwordsPrivate.startPasswordCheck()`, for example, the call is routed to `PasswordCheckDelegate::StartPasswordCheck()`.
+
+3.  **Orchestration, Not Execution**: The delegate's primary role is orchestration. It does not perform the leak checks itself.
+    *   To start a check, it uses a `BulkLeakCheckServiceAdapter` to call the `BulkLeakCheckService`.
+    *   To get insecure credentials, it queries the `InsecureCredentialsManager`.
+    *   It synthesizes the results from these different sources into a coherent state for the UI.
+
+4.  **Communicating with the UI**:
+    *   **Pull Model (`GetPasswordCheckStatus`)**: The UI can request the current status at any time. The delegate combines the state of the `BulkLeakCheckService` with its own internal progress tracking to provide a complete picture.
+    *   **Push Model (`PasswordsPrivateEventRouter`)**: As the state changes (e.g., a credential check finishes, the entire check completes), the delegate uses the `PasswordsPrivateEventRouter` to proactively send events to the UI, causing it to update dynamically without needing to poll.
+
+## 3. Security-Critical Logic
+
+As the boundary between the browser process and the WebUI renderer, the `PasswordCheckDelegate` has several security-critical responsibilities.
+
+*   **Data Sanitization for the UI**:
+    *   **`ConstructInsecureCredentialUiEntry`**: This function is responsible for converting an internal `CredentialUIEntry` object (which contains the password) into a `PasswordUiEntry` object that is safe to send to the renderer. It critically **omits the password value** and other sensitive data, sending only the necessary information for display (username, origin, compromise type, etc.). This is a key defense against a compromised renderer process being able to exfiltrate passwords.
+
+*   **Stable ID Management**:
+    *   The delegate uses an `IdGenerator` to create stable, opaque integer IDs for each credential sent to the UI.
+    *   When the UI sends a request back (e.g., "mute credential with id 123"), the delegate uses this ID to look up the original, trusted `CredentialUIEntry` object from its internal map. This prevents the UI from being able to craft a malicious request with arbitrary data; it can only act upon the credentials that the delegate has explicitly provided it an ID for.
+
+*   **State Management and Progress Tracking**:
+    *   The delegate uses a `PasswordCheckProgress` helper class to track the number of credentials being checked. This is more complex than a simple counter because the backend `BulkLeakCheckService` de-duplicates credentials before checking. The delegate correctly manages this by counting how many original passwords correspond to each unique canonical credential being checked.
+    *   This ensures the progress bar shown to the user is accurate and prevents UI confusion. A bug in this counting logic could lead to a stalled or incorrect progress bar, potentially causing a user to cancel a check that was still running.
+
+*   **Action Handling (`MuteInsecureCredential`)**: The delegate ensures that actions from the UI are applied to the correct credential by using the aforementioned ID-based lookup. This prevents any possibility of a "confused deputy" attack where the UI could trick the delegate into muting a different credential than the one the user selected.
+
+## 4. The Frontend: `checkup_section.ts`
+
+The `checkup_section.ts` file contains the TypeScript and Polymer-based implementation for the Password Checkup section of the `chrome://settings` page. It acts as the view layer, rendering the data provided by the C++ backend and forwarding user actions back to it.
+
+*   **API Communication**: The component communicates exclusively through the `PasswordManagerImpl` singleton, which is a JavaScript wrapper around the `chrome.passwordsPrivate` extension API. This provides a clean, well-defined boundary between the frontend and the browser process.
+
+*   **Data Flow (Backend -> Frontend)**: The component uses a combined pull-and-push model to stay in sync with the backend:
+    1.  **Initial State**: In its `connectedCallback`, it makes one-time calls to `getPasswordCheckStatus()` and `getInsecureCredentials()` to fetch the initial state when the page is loaded.
+    2.  **Live Updates**: It then registers listeners (`addPasswordCheckStatusListener`, `addInsecureCredentialsListener`) to receive asynchronous events from the `PasswordsPrivateEventRouter`. When the C++ backend has a new status or an updated list of insecure credentials, these listeners are invoked, updating the component's internal properties (`this.status_`, `this.compromisedPasswords_`, etc.) and causing the UI to re-render automatically via Polymer's data-binding system.
+
+*   **Action Flow (Frontend -> Backend)**: User actions are handled by simple, direct calls to the API wrapper:
+    *   **Start Check**: The "Check passwords" button's `on-click` handler calls `onPasswordCheckButtonClick_`, which in turn calls `PasswordManagerImpl.getInstance().startBulkPasswordCheck()`.
+    *   **Automatic Start**: The component observes the URL for a `?start_check=true` parameter. If found, it automatically calls `startBulkPasswordCheck()`, allowing other parts of Chrome (like Safety Hub) to link directly to the checkup and initiate a scan.
+    *   **Navigation**: Clicking on a result row (e.g., "Compromised passwords") uses a client-side `Router` to navigate to the appropriate details subpage.
+
+*   **Security Posture**: The frontend's security posture is strong due to its simplicity and clear separation of concerns.
+    *   **No Sensitive Data**: The frontend **never handles plaintext passwords**. All data it receives via the `passwordsPrivate` API in the `PasswordUiEntry` objects has already been sanitized by the `PasswordCheckDelegate`.
+    *   **No Business Logic**: The frontend contains no complex business logic. It simply renders the state provided by the backend and forwards user intents. All security-critical decisions (how to check, what to check, how to store results) are handled entirely within the C++ backend. This makes the frontend a "dumb" view, which is a robust security design.
+
+## 5. Related Components
+
+*   `chrome/browser/extensions/api/passwords_private/passwords_private_event_router.h`: The class responsible for sending asynchronous events (like status updates) from the C++ backend to the JavaScript frontend.
+*   `components/password_manager/core/browser/ui/bulk_leak_check_service_adapter.h`: The adapter used to interface with the `BulkLeakCheckService`.
+*   `components/password_manager/core/browser/ui/insecure_credentials_manager.h`: The service that provides the lists of weak and reused passwords.

--- a/security_notes/password_form_manager.md
+++ b/security_notes/password_form_manager.md
@@ -1,0 +1,59 @@
+# PasswordFormManager (`components/password_manager/core/browser/password_form_manager.cc`)
+
+## 1. Summary
+
+The `PasswordFormManager` is the stateful, central controller that orchestrates the entire lifecycle of a user's interaction with a credential form on a webpage. It acts as the "brain" of the password manager for a single form, from the moment the form is observed until a credential is saved, updated, or autofilled. It is responsible for parsing the form, fetching stored credentials, driving the autofill process, and managing the logic for provisional saving upon submission. Its complexity and central role make it one of the most security-critical components in the password management system.
+
+## 2. Core Responsibilities & State Machine
+
+A `PasswordFormManager` instance is created for each potential password form observed on a page. Its lifecycle is a complex state machine:
+
+1.  **Observation & Initialization**:
+    *   A `PasswordFormManager` is created with the initial `FormData` from the renderer.
+    *   It immediately kicks off an asynchronous fetch for stored credentials via its `FormFetcher`. This brings back best matches, federated matches, and blocklist status from the `PasswordStore`.
+
+2.  **Autofill**:
+    *   Once the `FormFetcher` returns, `OnFetchCompleted` is called.
+    *   The manager parses the observed form in `kFilling` mode using `FormDataParser`.
+    *   It may **delay filling** to wait for server-side predictions (`FormPredictions`) to arrive, which can improve accuracy. This is managed by the `AsyncPredictionsWaiter`.
+    *   Finally, `FillNow` calls `SendFillInformationToRenderer`, which provides the renderer with the credentials and instructions for filling the form.
+
+3.  **Submission & Provisional Saving**:
+    *   When the user submits the form, the `PasswordManager` calls `ProvisionallySave` on the corresponding `PasswordFormManager`.
+    *   The manager re-parses the submitted form data, this time in `kSaving` mode. The results can differ from filling mode because the submitted values are now known.
+    *   It creates a `pending_credentials` object, which represents the credential that might be saved.
+    *   It uses a `PasswordSaveManager` to handle the UI (e.g., the save/update bubble) and the final commit to the `PasswordStore`.
+
+## 3. Security-Critical Logic & Attack Surface
+
+The `PasswordFormManager` is a convergence point for untrusted data from web pages, renderer processes, and potentially inaccurate server predictions. Its attack surface is vast.
+
+*   **Username-First Flows (`HandleUsernameFirstFlow`)**: This is arguably the most complex and dangerous logic in the class. It attempts to link a username entered on one page to a password entered on a subsequent page.
+    *   **Risk**: A logic flaw could cause the manager to incorrectly associate a username from `site-A.com` with a password prompt on `site-B.com`, leading to credentials being saved for the wrong site or a user being prompted to save a credential with the wrong username.
+    *   **Mitigation**: The logic relies on a series of checks, including eTLD+1 matching (`IsPublicSuffixDomainMatch`), validating the freshness of the username data (`IsStale`), and a priority system (`UsernameFoundOutsideOfFormType`) to weigh the reliability of different signals (e.g., server predictions vs. local heuristics). A bug in any of these checks could break the security model.
+
+*   **Form Parsing (`FormDataParser`)**: The security of both filling and saving depends entirely on correctly identifying the username, password, and new password fields.
+    *   **Risk**: Mis-classification is a major risk. If a non-password field (e.g., a "PIN" or "Security Answer" field) is classified as a password, it could be saved as a password. If a password field is missed, a credential might not be saved at all.
+    *   **Reliance on Predictions**: The parser uses both local heuristics and server-side `FormPredictions`. While predictions improve accuracy, they also introduce a dependency on an external service. A malicious or incorrect prediction could theoretically lead to incorrect parsing, although the code has checks to validate prediction structure.
+
+*   **Provisional Saving (`ProvisionallySave`)**: This method takes the final `FormData` from the renderer and decides what to save.
+    *   **Risk**: The manager must correctly determine which form fields correspond to the username and password in the final submitted data. An error could lead to saving the wrong values.
+    *   **Username Updates (`OnUpdateUsernameFromPrompt`)**: When the user manually edits the username in the save bubble, the manager must correctly update its internal state. It tries to find the new username among other fields on the form (`all_alternative_usernames`) to improve crowdsourcing data, which is a complex and potentially fragile operation.
+
+*   **Generated Passwords**: The manager handles presaving generated passwords before the form is even submitted.
+    *   **Risk**: A logic error could cause a generated password to be associated with the wrong username or form, or fail to be saved entirely, forcing the user into a recovery flow.
+
+## 4. Key Data Structures
+
+*   **`observed_form_or_digest_`**: The canonical representation of the form being managed. This is either the `FormData` from the renderer or a `PasswordFormDigest` for non-HTML forms (like HTTP Basic Auth).
+*   **`parsed_submitted_form_`**: The result of parsing the form *after* submission. This is the "ground truth" for what the user actually submitted and is the basis for what gets saved.
+*   **`form_fetcher_`**: A helper class responsible for asynchronously fetching all relevant data from the `PasswordStore` for the current form.
+*   **`password_save_manager_`**: A helper class that encapsulates the logic for the "save" and "update" UI and the final communication with the `PasswordStore`.
+*   **`votes_uploader_`**: An optional helper that sends anonymized votes to Google's crowdsourcing backend to improve parsing heuristics.
+
+## 5. Related Components
+
+*   `components/password_manager/core/browser/form_data_parser.cc`: Performs the heavy lifting of parsing `FormData` into a structured `PasswordForm`.
+*   `components/password_manager/core/browser/form_fetcher.cc`: Handles the asynchronous fetching of credentials from the `PasswordStore`.
+*   `components/password_manager/core/browser/password_save_manager.cc`: Manages the UI and logic for saving or updating a credential after submission.
+*   `components/password_manager/core/browser/field_info_manager.cc`: Provides the data (`PossibleUsernameData`) needed to implement username-first flows.

--- a/security_notes/password_generation.md
+++ b/security_notes/password_generation.md
@@ -1,0 +1,63 @@
+# PasswordGenerationManager (`components/password_manager/core/browser/password_generation_manager.cc`)
+
+## 1. Summary
+
+The `PasswordGenerationManager` is a stateful controller that manages the lifecycle of a newly generated password, from the moment it is created and accepted by the user in the UI to the point it is permanently saved (committed) to the `PasswordStore`. It does not generate the password string itself, but rather orchestrates the complex "presave-then-commit" flow. Its primary security responsibility is to handle username conflicts, preventing a generated password from accidentally overwriting an existing credential for a different account on the same site.
+
+## 2. Architecture: A "Presave-then-Commit" State Machine
+
+The manager's architecture is designed to be robust against data loss (e.g., if the user closes the tab after generating a password but before submitting the form) and to handle security edge cases safely.
+
+1.  **Generation and Acceptance**: The flow begins when the user accepts a generated password in the UI. The `PasswordManagerDriver` calls `GeneratedPasswordAccepted` on the manager.
+
+2.  **Conflict Resolution**: Before doing anything else, the manager performs its most critical security check: it looks for username conflicts (`FindUsernameConflict`).
+    *   **No Conflict**: If the username on the form does not match any existing credential for that site, the flow proceeds directly to the "presave" step.
+    *   **Conflict Detected**: If a credential with the same username already exists, the manager **stops** the automatic flow. It clears the username from the pending credential and uses a special `PasswordDataForUI` class to construct and show an "Update password?" bubble. This forces the user to make an explicit decision about whether they intend to update the existing account's password.
+
+3.  **Presave**: If there is no conflict, the manager immediately calls `PresaveGeneratedPassword`. This creates a temporary, "presaved" entry in the `PasswordStore`. This entry is a complete `PasswordForm` but is treated as provisional. The manager stores a copy of this form in its `presaved_` member variable, which represents the core of its state. This ensures that if the user navigates away, the generated password is not lost.
+
+4.  **Commit**: After the user successfully submits the registration form, the `PasswordSaveManager` (acting as a `FormSaver`) calls `CommitGeneratedPassword`.
+    *   This method takes the final, submitted `PasswordForm`.
+    *   It uses the `presaved_` data as the "old primary key" to find and update the temporary entry in the `PasswordStore`, effectively making it a permanent, normal credential. This two-phase process ensures atomicity.
+    *   It also logs UMA metrics about how the user might have edited the generated password before submission.
+
+5.  **Cancellation**: If the user cancels the flow (e.g., by clearing the form field), `PasswordNoLongerGenerated` is called, which finds and removes the `presaved_` entry from the store, cleaning up the temporary state.
+
+## 3. Security-Critical Logic
+
+The manager's security posture is defined by its careful handling of potential credential overwrites.
+
+*   **Username Conflict Resolution**: This is the component's single most important security feature. By explicitly checking for `FindUsernameConflict` and halting the automatic save process, it prevents a scenario where a user, while creating a *new* account, could be tricked into overwriting the password for an *existing* account if the form pre-filled with the existing account's username. The use of the `PasswordDataForUI` model to show a dedicated prompt is a strong, user-facing security control.
+
+*   **Handling Password Changes on Conflict**: A clever and subtle security mechanism exists for the specific case where a username conflict is detected on a form that is also detected as a "change password" form. In this scenario, `PresaveGeneratedPassword` creates the presaved entry with a **random string** as its username element. This prevents the temporary, presaved credential from matching and overwriting *any* real credential in the database while it's in its provisional state, adding another layer of defense against data corruption.
+
+*   **State Integrity**: The `presaved_` member variable is the link between the initial generation and the final commit. The integrity of this state is critical. If this state were to be corrupted or lost, the manager would be unable to find the correct provisional entry to update, potentially leading to an orphaned temporary credential or a failure to save the final password. The class's simple, well-defined lifecycle methods (`Presave`, `Commit`, `PasswordNoLongerGenerated`) ensure this state is managed correctly.
+
+## 4. Triggering Generation: `PasswordGenerationFrameHelper`
+
+While the `PasswordGenerationManager` handles the *saving* of a generated password, the `PasswordGenerationFrameHelper` is the component responsible for the *triggering* of the feature. It lives alongside the `PasswordManagerDriver` and acts as the direct interface to the renderer for all generation-related events.
+
+*   **Determining Generation Availability (`IsGenerationEnabled`)**: This is the primary security gate for the feature. Before any UI is shown, this method is called to ensure a strict set of preconditions are met:
+    1.  The user must be able to save passwords (i.e., the password store is working).
+    2.  The user must have password saving enabled in settings.
+    3.  The feature must be enabled by the `PasswordFeatureManager` (which often implies the user is signed-in and syncing).
+    4.  The current URL must **not** be a `google.com` domain, as a hardcoded security measure to avoid interfering with Google's own account management flows.
+
+*   **Processing Site-Specific Requirements**: The helper is responsible for gathering password requirements that will be used to generate a compliant password.
+    *   `ProcessPasswordRequirements` receives Autofill server predictions for the fields on a form. If these predictions include password requirements (e.g., `max_length`, required character classes), they are stored in the `PasswordRequirementsService`.
+    *   This allows Chrome to learn from crowdsourced data what kind of password a specific website expects.
+
+*   **Generating the Password String (`GeneratePassword`)**: When the user requests a password, this method is called.
+    1.  It retrieves any stored requirements for the specific site and form from the `PasswordRequirementsService`.
+    2.  It calculates the final password length, respecting the `max_length` attribute from the HTML form field and the server-provided requirements.
+    3.  It calls the low-level `autofill::GeneratePassword(spec)` function, passing it the final specification. This function is responsible for the actual cryptographic random string generation.
+
+*   **Communication with `PasswordFormManager`**: After the `PasswordFormManager` parses a form, if it identifies a field as a new password field (e.g., on a registration form), it calls `password_generation_helper->AddManualGenerationEnabledField()`. This is how the helper learns which specific fields on the page are allowed to display the "Suggest strong password" UI.
+
+## 5. Related Components
+
+*   `components/password_manager/core/browser/password_generation_frame_helper.h`: The component analyzed in this section, responsible for triggering generation.
+*   `components/password_manager/core/browser/password_manager_driver.h`: The owner of the helper, which facilitates communication with the renderer process.
+*   `components/password_manager/core/browser/password_save_manager.h`: The component that owns the `PasswordGenerationManager` and calls `CommitGeneratedPassword` after a successful form submission.
+*   `components/password_manager/core/browser/password_requirements_service.h`: The service responsible for storing and retrieving site-specific password requirements.
+*   `components/autofill/core/common/password_generation.h`: (Not directly analyzed but inferred) The location of the actual password generation algorithm that creates the secure password string.

--- a/security_notes/password_import_export.md
+++ b/security_notes/password_import_export.md
@@ -1,0 +1,53 @@
+# Password Import and Export
+
+## 1. Summary
+
+Password import and export are highly sensitive operations that allow users to move their credentials into and out of the Chrome password store. The export process creates a plaintext `.csv` file of all passwords, representing a significant security risk if handled improperly. The import process parses a file and adds its contents to the password store, creating a risk of data corruption or malicious entry if the input is not handled carefully. The `PasswordsPrivateDelegateImpl` serves as the initial entry point for these operations from the UI, but it quickly delegates the core logic to a dedicated helper class, the `PasswordManagerPorter`.
+
+## 2. The Export Flow
+
+The export process is initiated from the settings UI and is designed with a critical security gate: user re-authentication.
+
+*   **Initiation (`PasswordsPrivateDelegateImpl::ExportPasswords`)**:
+    *   When the user clicks the "Export passwords" button in the UI, the `passwordsPrivate.exportPasswords()` API function is called, which is handled by this method in the delegate.
+    *   The method's first and only action is to call `AuthenticateUser()`. This triggers a platform-specific OS-level authentication prompt (e.g., Touch ID on macOS, Windows Hello on Windows) to confirm the user's presence and authorization. This is a crucial step to prevent malware or an unauthorized physical user from silently exporting all passwords.
+
+*   **Authentication Result (`OnExportPasswordsAuthResult`)**:
+    *   If authentication is successful, this callback is invoked.
+    *   It then immediately delegates the entire export process to `password_manager_porter_->Export()`.
+
+*   **The Exporter (`PasswordManagerPorter`)**:
+    *   The `PasswordManagerPorter` is the class that contains the actual logic for serializing the passwords and writing them to a file.
+    *   It retrieves the full list of credentials from the `SavedPasswordsPresenter`.
+    *   It then serializes this list into a standard CSV format with the columns `name,url,username,password,note`.
+    *   It presents a native "Save As" file dialog to the user, allowing them to choose the destination for the plaintext `.csv` file.
+
+*   **Security Considerations**:
+    *   **Re-authentication is Mandatory**: The entire security of the export feature rests on the mandatory OS-level re-authentication step. This is a robust defense against non-interactive attacks.
+    *   **Plaintext Risk**: The fundamental risk is the creation of a plaintext file containing all of the user's passwords. The UI provides warnings about the sensitivity of this file, but the ultimate security depends on the user's handling of the exported data.
+    *   **Serialization**: The serialization logic is straightforward, but a bug could lead to a malformed CSV file. The use of a standard format mitigates the risk of creating a file that cannot be imported by other password managers.
+
+## 3. The Import Flow
+
+The import process is more complex than exporting, as it involves parsing an untrusted file and handling potential conflicts with the user's existing passwords.
+
+*   **Initiation (`PasswordsPrivateDelegateImpl::ImportPasswords`)**:
+    *   The flow begins when the user clicks the "Import passwords" button in the UI.
+    *   The delegate calls `PasswordManagerPorter::Import`, which immediately opens a native file selection dialog for the user to choose a `.csv` file.
+
+*   **Parsing and Conflict Resolution (`PasswordManagerPorter` & `PasswordImporter`)**:
+    *   Once a file is selected, `PasswordManagerPorter` creates a `password_manager::PasswordImporter` object.
+    *   The `PasswordImporter` is the "worker" class responsible for parsing the CSV file. It reads each row and attempts to convert it into a valid `PasswordForm`.
+    *   Crucially, after parsing, the importer does not immediately save the passwords. Instead, it performs a **conflict analysis**. It compares each imported credential against the user's existing passwords (retrieved via the `SavedPasswordsPresenter`) to identify entries that would be overwritten.
+    *   If conflicts are found, the import process **pauses** and returns a list of the conflicting entries to the UI layer (`PasswordsPrivateDelegateImpl`). The UI then displays a conflict resolution dialog, asking the user to select which specific passwords they want to save and which they want to skip.
+
+*   **Continuation (`PasswordsPrivateDelegateImpl::ContinueImport`)**:
+    *   After the user makes their selections in the UI, this method is called with the list of chosen credential IDs.
+    *   It may require another OS-level re-authentication check to confirm the user's intent to modify their password store.
+    *   If authenticated, it calls `password_manager_porter_->ContinueImport()`, passing along the user's selections.
+    *   The `PasswordImporter` then performs the final step, calling `presenter_->AddCredential()` only for the user-approved entries.
+
+*   **Security Considerations**:
+    *   **Parsing Untrusted Input**: The primary risk is in parsing the `.csv` file. A malformed file could potentially lead to parsing errors, hangs, or even memory corruption bugs in the CSV parsing library.
+    *   **Conflict Resolution is Critical**: The conflict resolution step is a vital security and data integrity feature. Without it, a malicious or simply outdated import file could silently overwrite a user's current, correct passwords. By pausing the import and forcing the user to make an explicit choice, the risk of unintentional data loss is significantly mitigated.
+    *   **Re-authentication**: Requiring re-authentication before finalizing the import adds another layer of defense, ensuring that malware cannot programmatically trigger the final step of the import process without user consent.

--- a/security_notes/password_leak_detection.md
+++ b/security_notes/password_leak_detection.md
@@ -1,0 +1,70 @@
+# Password Leak Detection (`components/password_manager/core/browser/leak_detection/`)
+
+## 1. Summary
+
+The Password Leak Detection feature is a highly sophisticated privacy-preserving mechanism designed to warn users if their credentials have appeared in a known data breach. The implementation, centered around `LeakDetectionCheckImpl`, orchestrates a complex cryptographic protocol to query a Google-owned database of leaked credentials. The core security guarantee is that **plaintext usernames and passwords are never sent to Google**. Instead, the client performs a "blinded" query, ensuring that Google cannot learn which credential is being checked, and the user's privacy is maintained.
+
+## 2. Architecture: A Parallelized Cryptographic Flow
+
+The process of checking a single credential (`username`, `password` pair) is managed by `LeakDetectionCheckImpl` and follows a carefully parallelized flow to minimize latency:
+
+1.  **Start**: The check begins with `LeakDetectionCheckImpl::Start()`.
+
+2.  **Parallel Operations**: A helper class, `RequestPayloadHelper`, immediately kicks off two operations in parallel:
+    *   **Authentication**:
+        *   If the user is signed into a Google account, it requests an OAuth2 access token via `RequestAccessToken`. This token is used to authenticate the request to Google's servers.
+        *   If the user is not signed in, it proceeds without a token, relying on a less-privileged API key for the request.
+    *   **Payload Preparation**:
+        *   Simultaneously, it calls `PrepareSingleLeakRequestData` to perform the client-side cryptography. This is the most security-sensitive part of the request pipeline. It takes the plaintext username and password and transforms them into a blinded, encrypted query payload. A temporary, single-use `encryption_key` is also generated during this step, which is kept exclusively on the client.
+
+3.  **Synchronization & Network Request**:
+    *   The `RequestPayloadHelper` waits for both the auth token (if applicable) and the cryptographic payload to be ready.
+    *   Once both are available, it calls `LeakDetectionCheckImpl::DoLeakRequest`.
+    *   `DoLeakRequest` creates a `LeakDetectionRequest` object, which constructs and sends the final HTTPS request to Google's servers. The request contains the blinded payload and the authentication token/API key.
+
+4.  **Response Analysis**:
+    *   The server's response is handled by `OnLookupSingleLeakResponse`. The response does not contain a simple "yes" or "no". Instead, it contains a list of `encrypted_leak_match_prefixes`.
+    *   This encrypted data is passed to the `AnalyzeResponse` function, along with the secret `encryption_key` that was generated and stored on the client in step 2.
+    *   `AnalyzeResponse` performs the final client-side cryptographic step: it uses the key to determine if the user's specific credential corresponds to any of the encrypted data returned by the server.
+
+5.  **Result**: The final result (`kLeaked` or `kNotLeaked`) is passed to the `LeakDetectionDelegateInterface`, which is responsible for updating the `PasswordForm` in the database and triggering a user-facing notification.
+
+## 3. Security-Critical Logic & Cryptographic Protocol
+
+The entire security of this feature hinges on the cryptographic protocol that allows for a private lookup.
+
+*   **Blinded Request (`PrepareSingleLeakRequestData`)**: The client does not send `hash(password)`. Instead, it computes a blinded version of the credential. The protocol likely involves:
+    *   Computing a hash of the username to find a bucket of credentials on the server.
+    *   Hashing the password multiple times, including with a server-side public key, to create a value that can be checked by the server without revealing the original password hash.
+    *   Generating a client-side secret encryption key (`encryption_key_`) that will be needed to decrypt the server's response.
+
+*   **Server-Side Lookup**: The server receives the blinded query. It finds all credentials associated with the (hashed) username prefix. It cannot identify the specific user or their password from the request. It returns a set of encrypted data that corresponds to the potential matches.
+
+*   **Client-Side Analysis (`AnalyzeResponse`)**: This is the final, critical step. The client receives the encrypted data from the server. Using the secret `encryption_key_` it generated earlier, it can "un-blind" the response and check if its exact hashed password is in the set returned by the server. Because the client generated the key, only it can perform this final check. This ensures that Google never knows the final result of the lookup.
+
+*   **Enterprise Policy (`IsURLBlockedByPolicy`)**: The feature includes a check against the `PasswordManagerLeakDetectionURLAllowlist` enterprise policy. This ensures that credentials for sensitive internal domains specified by a system administrator are never sent for a leak check, respecting enterprise security boundaries.
+
+## 4. The Network Request (`LeakDetectionRequest`)
+
+The `LeakDetectionRequest` class is responsible for the final step of the process: taking the cryptographically prepared payload, constructing an HTTPS request, sending it to the Google API endpoint, and parsing the response.
+
+*   **Endpoint**: The request is sent to a hardcoded endpoint, `kLookupSingleLeakEndpoint`.
+
+*   **Request Construction (`LookupSingleLeak`)**:
+    *   **Authentication**: The request includes an `Authorization` header. For signed-in users, this is a `Bearer` token containing the OAuth2 access token. For signed-out users, it uses an `x-goog-api-key` header with a hardcoded API key.
+    *   **Payload**: The `LookupSingleLeakPayload` (containing the blinded username/password data) is serialized into a `LookupSingleLeakRequest` protocol buffer. This binary data is sent as the `POST` body with a `Content-Type` of `application/x-protobuf`.
+    *   **Metadata**: The request includes the `ClientUseCase` (e.g., `CHROME_SIGN_IN_CHECK`, `CHROME_BULK_SYNCED_PASSWORDS_CHECK`) to give the server context about why the check is being performed. It may also include a `RequestCriticality` header to help the server with load shedding.
+
+*   **Response Handling (`OnLookupSingleLeakResponse`)**:
+    *   The response handler robustly checks for network errors and HTTP status codes, specifically handling `429 Too Many Requests` to signal a quota limit issue back to the caller.
+    *   On success, it parses the response body as a `LookupSingleLeakResponse` protobuf.
+    *   It extracts the two key fields from the response: `reencrypted_lookup_hash` and the list of `encrypted_leak_match_prefix`.
+    *   This data is packaged into a `SingleLookupResponse` struct and sent back to `LeakDetectionCheckImpl` for the final, client-side analysis.
+
+This class acts as a clean boundary between the complex cryptographic setup and the standard networking layer. Its primary security responsibility is to ensure that the correct authentication headers and the correctly serialized, privacy-preserving payload are sent over a secure HTTPS channel.
+
+## 5. Related Components
+
+*   `components/password_manager/core/browser/leak_detection/leak_detection_request_utils.cc`: This file contains the core cryptographic logic (`PrepareSingleLeakRequestData` and `AnalyzeResponse`) and is the most important dependency for understanding the privacy guarantees.
+*   `components/password_manager/core/browser/leak_detection/leak_detection_check_impl.cc`: The central orchestrator that drives the entire leak check process, from requesting an auth token to analyzing the final response.
+*   `components/password_manager/core/browser/leak_detection/leak_detection_delegate_interface.h`: The interface used by `LeakDetectionCheckImpl` to report its results (success, failure, or leak found) to the rest of the password manager.

--- a/security_notes/password_renderer_agent.md
+++ b/security_notes/password_renderer_agent.md
@@ -1,0 +1,44 @@
+# Password Renderer Agent (`components/autofill/content/renderer/password_autofill_agent.cc`)
+
+## 1. Summary
+
+The `PasswordAutofillAgent` is the renderer-side counterpart to the browser-process password management system. It lives within the sandboxed renderer process for each frame and is responsible for all direct interaction with the DOM. Its core duties are to receive autofill data from the browser, securely fill it into web forms, and report user interactions and form submissions back to the browser. As the component that bridges the trusted browser process and the untrusted web content, its design is critical to the security of the entire password autofill feature.
+
+## 2. Architecture: A Mojo-Driven DOM Manipulator
+
+The agent's architecture is that of a trusted executor operating in an untrusted environment. It receives commands from the browser via a Mojo interface and executes them with minimal local decision-making.
+
+1.  **Browser-to-Renderer Communication**: The agent implements the `mojom::PasswordAutofillAgent` interface. Its primary entry point is `ApplyFillDataOnParsingCompletion`, which is called by the browser process after it has parsed a form and fetched relevant credentials. This method receives a `PasswordFormFillData` object containing the username and password values to be filled, along with the specific `FieldRendererId`s of the target elements.
+
+2.  **Renderer-to-Browser Communication**: The agent holds a remote to a `mojom::PasswordManagerDriver` interface, which it uses to send information back to the browser process. Key events it reports include:
+    *   `PasswordFormsParsed` and `PasswordFormsRendered`: Sent when the agent scans the DOM, providing the browser with the structure of potential credential forms.
+    *   `PasswordFormSubmitted`: Sent after the agent detects a form submission. It sends the full `FormData` back to the browser for analysis.
+    *   `InformAboutUserInput`: Notifies the browser whenever the user modifies a field in a password form.
+
+3.  **DOM Interaction**: The agent uses utility functions from `components/autofill/content/renderer/form_autofill_util.h` to interact with the DOM. All element identification is based on the stable `FieldRendererId` provided by the browser, not on potentially unreliable information like element names or IDs from the DOM itself.
+
+4.  **Prerendering Handling**: The agent has a special `DeferringPasswordManagerDriver` that it uses when the page is being prerendered. This class intercepts all outgoing Mojo calls and queues them to be executed only after the page is actually activated. This is a crucial mechanism to prevent a background prerendering page from interacting with the password manager UI or state.
+
+## 3. Security-Critical Logic & Attack Surface
+
+The agent's primary security responsibility is to prevent a malicious webpage from stealing a user's password as it is being filled.
+
+*   **Secure Filling (`PasswordValueGatekeeper`)**: This is the single most important security mechanism in the class. When autofilling a password, the agent does not immediately set the `.value` of the password field.
+    1.  Instead, `FillFieldAutomatically` calls `SetSuggestedValue`, which places the password in an internal Blink state, and then registers the element with the `PasswordValueGatekeeper`.
+    2.  The gatekeeper holds a list of these "pending" password fields.
+    3.  Only after a `UserGestureObserved()` event (e.g., a click or keypress) is received does the gatekeeper's `OnUserGesture()` method execute.
+    4.  This method iterates through the pending fields and calls `SetAutofillValue`, which finally transfers the password from the internal suggested state into the element's actual value, making it visible to the DOM and accessible to scripts.
+    *   **Security Guarantee**: This two-phase process ensures that a page cannot use JavaScript to programmatically trigger an autofill and immediately read the filled password. The fill is only completed after the browser has observed a legitimate user interaction with the page, defeating scripted attacks.
+
+*   **Frame Security Checks**:
+    *   `FrameCanAccessPasswordManager()`: Before performing any actions, the agent verifies that the frame's origin is allowed to use the password manager. It explicitly blocks non-HTTP/HTTPS schemes (e.g., `about:`, `data:`) and respects Blink's `CanAccessPasswordManager` security policy.
+    *   `IsInCrossOriginIframeOrEmbeddedFrame()`: When filling credentials, the agent checks if the target element is in a cross-origin iframe relative to its parent frames. This check helps mitigate attacks where a malicious ad or embedded content could try to create a password field to steal credentials intended for the top-level site.
+
+*   **Renderer as a "Dumb" Executor**: The agent makes very few security decisions on its own. It receives instructions from the browser (e.g., "fill this password into the field with this ID") and executes them. When a form is submitted, it does not decide what to save; it sends the *entire form's data* back to the browser process (`PasswordFormManager`), which then re-validates everything in a privileged context before making a decision. This minimizes the trust placed in the sandboxed renderer process.
+
+## 4. Related Components
+
+*   `mojom::PasswordAutofillAgent` & `mojom::PasswordManagerDriver`: The Mojo interfaces that define the security boundary and communication channel between the renderer and the browser.
+*   `components/autofill/content/renderer/form_autofill_util.h`: The library of functions for safely finding and manipulating form elements in the DOM based on renderer IDs.
+*   `components/password_manager/core/browser/password_manager.cc`: The browser-side component that ultimately drives the agent via the Mojo interface.
+*   `PasswordGenerationAgent`: The renderer-side agent responsible for handling the password generation flow, which works in close concert with the `PasswordAutofillAgent`.

--- a/security_notes/password_store.md
+++ b/security_notes/password_store.md
@@ -1,0 +1,53 @@
+# PasswordStore (`components/password_manager/core/browser/password_store/password_store.cc`)
+
+## 1. Summary
+
+The `PasswordStore` class is the central, thread-safe, asynchronous frontend for all password database operations in Chromium. It lives on the main UI thread and acts as the primary API for any browser component that needs to create, retrieve, update, or delete user credentials. It does not perform any storage operations itself; instead, it serves as a crucial gatekeeper that marshals requests to the `PasswordStoreBackend`, which executes them on a background thread. This design prevents blocking the UI thread with slow I/O and provides a single, controlled point of entry for security-sensitive password data.
+
+## 2. Architecture: A Thread-Safe Facade
+
+The core architectural pattern of the `PasswordStore` is the separation of the public-facing API from the implementation details of the storage mechanism.
+
+*   **UI Thread (Frontend)**: The `PasswordStore` object itself lives on the main browser thread. It exposes a clean, asynchronous API (e.g., `AddLogin`, `GetLogins`) to its clients, such as the `PasswordFormManager`. All its public methods are expected to be called on this thread.
+
+*   **Background Thread (Backend)**: All actual I/O operations (reading from or writing to the database) are delegated to a `PasswordStoreBackend` object. The `PasswordStore` posts tasks to the backend, which runs on a dedicated background thread to avoid jank.
+
+*   **Asynchronous Communication**: Communication is handled via callbacks.
+    *   Requests from the UI thread to the backend are made via `...Async` methods (e.g., `backend_->AddLoginAsync(...)`).
+    *   Results are returned from the backend to the UI thread using callbacks, typically wrapped in `base::BindPostTask` to ensure they are executed safely back on the main thread.
+    *   For retrieving data, the `PasswordStoreConsumer` class is used with a `base::WeakPtr` to safely handle cases where the requester might be destroyed before the data is ready.
+
+This asynchronous, multi-threaded design is fundamental to the security and responsiveness of the password manager.
+
+## 3. Security-Critical Logic & Operations
+
+*   **`UpdateLoginWithPrimaryKey`**: This is one of the most security-sensitive methods. It replaces an old credential with a new one. The implementation contains critical logic to sanitize the security metadata (`password_issues`) of the credential:
+    *   If the password value changes, all `password_issues` (leaked, phished, weak, etc.) are cleared. This is correct because the old issues are no longer relevant to the new password.
+    *   If only the username changes, the leaked and phished flags are cleared, as these are tied to the username-password pair.
+    *   A bug in this logic could cause a user who just fixed a leaked password to continue seeing a "leaked password" warning, eroding trust in the feature.
+
+*   **`AddLogins` / `UpdateLogins` Sanity Check**: These methods include a `CHECK` to ensure that any `PasswordForm` marked as `blocked_by_user` (i.e., a "never save for this site" entry) does not also contain a username and password. This is a vital sanity check to prevent a logic error from accidentally storing a credential in a blocklist entry.
+
+*   **Backend Abstraction (`PasswordStoreBackend`)**: The `PasswordStore`'s security model heavily relies on its backend. By abstracting the backend, Chromium can use the most secure storage mechanism available on each platform:
+    *   **macOS**: Keychain
+    *   **Windows**: DPAPI / Credential Locker
+    *   **Linux**: GNOME Keyring / KWallet
+    *   **Android**: Google Password Manager service
+    This abstraction ensures that plaintext passwords are never stored directly on disk and are protected by OS-level encryption and security measures.
+
+*   **Shutdown and Cleanup (`ShutdownOnUIThread`)**: The class has a careful shutdown procedure that is essential for preventing use-after-free vulnerabilities. It transfers ownership of the `backend_` to the shutdown task and nulls out its local pointer, ensuring no further requests can be made to a partially destroyed object.
+
+## 4. Attack Surface & Risks
+
+*   **Race Conditions**: The asynchronous, multi-threaded nature of the store makes it susceptible to race conditions. A logic error in how callbacks are chained or how state is managed between the two threads could lead to data corruption (e.g., an old password overwriting a new one). The code uses `base::BarrierCallback` to mitigate this for multi-step operations, ensuring all prerequisite tasks are finished before the final callback is invoked.
+
+*   **Information Leaks**: The primary risk is the accidental exposure of `PasswordForm` data. While the `PasswordStore` itself is careful, any component that interacts with it receives `PasswordForm` objects. A bug in a consumer could lead to plaintext credentials being logged or sent over the network.
+
+*   **Incorrect State Management**: The `PasswordStore` handles requests that arrive before its backend is fully initialized by queueing them in a `post_init_callback_`. A flaw in this initialization sequence could cause early requests to be dropped or handled incorrectly, potentially leading to a user's password not being saved.
+
+## 5. Related Components
+
+*   `components/password_manager/core/browser/password_store/password_store.h`: The header file defining the `PasswordStore` interface.
+*   `components/password_manager/core/browser/password_store/password_store_backend.h`: The interface for the platform-specific backend that performs the actual storage operations.
+*   `components/password_manager/core/browser/password_form.h`: The data structure representing a single credential.
+*   `components/password_manager/core/browser/password_store/password_store_consumer.h`: The interface for clients that wish to asynchronously retrieve results from the `PasswordStore`.

--- a/security_notes/passwords_grouper.md
+++ b/security_notes/passwords_grouper.md
@@ -1,0 +1,39 @@
+# PasswordsGrouper (`components/password_manager/core/browser/ui/passwords_grouper.cc`)
+
+## 1. Summary
+
+The `PasswordsGrouper` is a specialized helper class with a single, critical responsibility: to take a flat list of passwords and passkeys and group them based on site affiliation. It is the component that allows the Chrome password manager UI to present credentials for `accounts.google.com`, `youtube.com`, and a Google Android app as a single, unified entry for "Google." It is a key dependency of the `SavedPasswordsPresenter` and is fundamental to creating a user-friendly and intuitive view of the user's credential store.
+
+## 2. Architecture: An Affiliation-Driven Processor
+
+The grouper's architecture is that of a data processor that relies on an external service for its core logic.
+
+1.  **Input**: The process begins when `SavedPasswordsPresenter` calls `GroupCredentials`, providing a list of all `PasswordForm` objects and `PasskeyCredential` objects.
+
+2.  **Facet Creation**: The first step is to convert every credential into a canonical "facet." A facet is a URI that uniquely identifies a website or an application (e.g., `https://accounts.google.com`, `android://com.google.android.gm`). The `GetFacetRepresentation` helper function is responsible for this conversion, ensuring that different forms of a URL or sign-on realm are normalized into a consistent format.
+
+3.  **Affiliation Service Query**: The grouper sends the complete list of facets to the `AffiliationService`. This service (which is outside the scope of this analysis but can be treated as a trusted oracle) maintains the database of relationships between websites and apps. It returns a list of `GroupedFacets` objects, where each object contains a list of affiliated facets and associated branding information (e.g., the name "Google" and the Google icon URL).
+
+4.  **Internal Grouping (`GroupPasswordsImpl`)**: This is the core logic of the class. It receives the affiliation data and performs a two-level grouping:
+    *   **First Level (by Affiliation)**: It creates a unique `GroupId` for each affiliated group returned by the service. It then iterates through every password and passkey, looks up its facet in the affiliation data, and assigns it to the corresponding `GroupId`. This is stored in the `map_group_id_to_credentials_` member.
+    *   **Second Level (by Credential)**: Within each affiliation group, it further groups passwords by a `UsernamePasswordKey`. This ensures that if a user has multiple, distinct credentials for the same service (e.g., a personal and a work account for Google), they are still treated as separate entries within the "Google" group.
+
+5.  **Output**: The class exposes methods like `GetAffiliatedGroupsWithGroupingInfo` that allow clients to retrieve the final, processed list. This list is sorted alphabetically for display in the UI.
+
+## 3. Security-Critical Logic
+
+The security of the `PasswordsGrouper` is primarily concerned with data integrity and preventing incorrect credential association.
+
+*   **Trust in `AffiliationService`**: The grouper's most significant security property is its **total trust** in the data provided by the `AffiliationService`. The correctness of the entire grouping feature depends on the affiliation data being accurate and not subject to manipulation. If the service were to incorrectly report that `evil.com` is affiliated with `google.com`, the grouper would faithfully group them together, which could have severe security implications (e.g., tricking a user into thinking a phishing site is legitimate).
+
+*   **Canonicalization (`GetFacetRepresentation`)**: The logic for canonicalizing a `PasswordForm` into a facet is security-sensitive. It must correctly handle various URL formats, federated credentials, and Android application URIs. A bug in this normalization could cause a credential to be mis-identified, leading it to be excluded from its correct group or, in a worst-case scenario, placed in the wrong one.
+
+*   **Data Integrity and Memory Safety**: The class performs complex manipulations of nested maps and vectors. The presence of a `CheckHeapIntegrity` method (guarded by a feature flag) suggests that memory safety has been a concern in this component's history. A memory corruption bug during the grouping process could lead to unpredictable behavior or security vulnerabilities. The check itself is a good defensive programming practice.
+
+*   **Fallback Icon URL Construction**: When branding information is not available from the `AffiliationService`, the grouper constructs a fallback icon URL by calling out to a Google favicon service. This involves embedding the credential's URL as a query parameter. The code correctly uses `base::EscapeQueryParamValue` to mitigate the risk of URL parsing or injection issues in the constructed favicon URL.
+
+## 4. Related Components
+
+*   `components/affiliations/core/browser/affiliation_service.h`: The external service that provides the ground truth for which websites and applications are related. This is the most critical dependency.
+*   `components/password_manager/core/browser/ui/saved_passwords_presenter.h`: The sole client and owner of the `PasswordsGrouper`.
+*   `components/password_manager/core/browser/ui/credential_ui_entry.h`: The unified data structure that the grouper produces as its output.

--- a/security_notes/saved_passwords_presenter.md
+++ b/security_notes/saved_passwords_presenter.md
@@ -1,0 +1,45 @@
+# SavedPasswordsPresenter (`components/password_manager/core/browser/ui/saved_passwords_presenter.cc`)
+
+## 1. Summary
+
+The `SavedPasswordsPresenter` is a high-level data management class that acts as the primary source of truth for all saved credentials (both passwords and passkeys) presented in the Chrome UI. It is a critical component that sits between the low-level storage (`PasswordStore`, `PasskeyModel`) and the UI logic layers (`PasswordCheckDelegate`, `InsecureCredentialsManager`). Its core responsibilities are to fetch raw credential data from multiple sources, process it into a unified and user-friendly format, and provide a stable, observable interface for its clients to read and modify this data.
+
+## 2. Architecture: A Unifying Data Abstraction Layer
+
+The presenter's architecture is designed to abstract away the complexity of Chromium's multi-store and multi-type credential system.
+
+1.  **Multi-Source Fetching**: Upon initialization (`Init`), the presenter asynchronously fetches all credentials from up to three sources:
+    *   `ProfilePasswordStore`: For device-local passwords.
+    *   `AccountPasswordStore`: For passwords synced to the user's Google Account.
+    *   `PasskeyModel`: For all passkeys (WebAuthn credentials).
+    It uses a counter (`pending_store_updates_`) to track when all asynchronous fetches are complete.
+
+2.  **Data Aggregation and Grouping**:
+    *   Raw `PasswordForm` objects are stored in an internal map (`sort_key_to_password_forms_`).
+    *   The presenter's key architectural feature is its use of a `PasswordsGrouper`. Once all data is fetched, it passes the complete list of passwords and passkeys to the grouper.
+    *   The `PasswordsGrouper` performs the complex logic of combining credentials from different sources based on affiliation data (e.g., grouping `google.com` and `youtube.com` together). The output of this process is a list of `CredentialUIEntry` objects, which is the unified data model that clients interact with.
+
+3.  **Observable Interface**: The presenter implements the Observer pattern.
+    *   It observes the underlying `PasswordStore` and `PasskeyModel` for any real-time changes.
+    *   When changes occur (`OnLoginsChanged`, `OnPasskeysChanged`), it updates its internal cache and re-runs the grouping logic.
+    *   It then notifies its own observers (like `PasswordCheckDelegate`) that the list of saved credentials has changed, ensuring the entire UI layer remains in sync.
+
+## 3. Security-Critical Logic
+
+As the gatekeeper for all modifications to the user's saved credentials, the presenter contains highly security-sensitive logic.
+
+*   **`EditPassword` - The Core Modification Logic**: This is the most critical function in the class. It is called when a user edits a password in the settings UI.
+    *   **Conflict Detection**: Before applying any change, it performs a crucial validation check: `IsUsernameAlreadyUsed`. This ensures that a user cannot change a credential's username to one that already exists for the same site in the same store, which would effectively overwrite a different credential. This is a primary defense against data corruption.
+    *   **Correct API Usage**: The function correctly distinguishes between changing a password and changing a username. When a username is changed (which alters the primary key of the `PasswordForm`), it correctly calls the `PasswordStore::UpdateLoginWithPrimaryKey` method. For all other changes, it uses the standard `PasswordStore::UpdateLogin`. Using the wrong API could lead to orphaned or duplicated entries.
+    *   **Password Issue Invalidation**: The logic correctly understands the security implications of editing a password. When the password value is changed, it clears *all* `password_issues` associated with the credential, correctly assuming that the old leak/weakness/reuse status is no longer valid for the new password.
+
+*   **`MoveCredentialsToAccount`**: This function handles the logic for moving a password from the local profile store to the synced account store. Its security relies on correctly checking if a credential for the same `signon_realm` already exists in the account store before adding the new one and deleting the old one. This prevents accidental duplication or overwrites.
+
+*   **`RemoveCredential`**: This function correctly identifies all `PasswordForm` objects associated with a given `CredentialUIEntry` (since a single UI entry can represent multiple forms due to grouping) and calls `RemoveLogin` on the appropriate store for each one. This ensures that when a user deletes a credential, all underlying database entries are properly removed.
+
+## 4. Related Components
+
+*   `components/password_manager/core/browser/ui/passwords_grouper.h`: The helper class responsible for the complex logic of grouping affiliated credentials.
+*   `components/password_manager/core/browser/password_store.h`: The underlying storage interface for passwords. The presenter is its primary "write" client for UI-initiated changes.
+*   `components/webauthn/core/browser/passkey_model.h`: The underlying storage interface for passkeys.
+*   `chrome/browser/extensions/api/passwords_private/password_check_delegate.h`: A primary client of the presenter, which uses it as the source of truth for the Password Checkup feature.


### PR DESCRIPTION
This change introduces a comprehensive set of security analysis notes for the Chromium password management system. The notes cover the end-to-end lifecycle of a credential, from storage and form-filling to leak detection and UI presentation.

The analysis is documented in a series of new markdown files in the `security_notes/` directory, with each file focusing on a specific, critical component:

- `PasswordStore`
- `PasswordFormManager`
- `PasswordAutofillManager`
- `LeakDetectionCheck` & `BulkLeakCheckService`
- `InsecureCredentialsManager`
- `PasswordCheckDelegate` (UI Backend)
- `PasswordGenerationManager`
- `PasswordManagerPorter` (Import/Export)
- `PasswordsGrouper`
- `PasswordAutofillAgent` (Renderer)

A `SUMMARY.md` provides a high-level overview of the system's architecture, security principles, and key areas of risk. These notes serve as a valuable resource for future security reviews and onboarding.