### PR TITLE
Create security notes for RenderFrameImpl and related components

### DIFF
--- a/security_notes/bad_message.md
+++ b/security_notes/bad_message.md
@@ -1,0 +1,35 @@
+# Security Note: Bad Message Handling (`content/browser/bad_message.cc`)
+
+## 1. Summary
+
+The `bad_message` namespace contains Chromium's primary mechanism for handling malformed or unexpected IPC messages from a less-privileged process, typically a renderer. Its purpose is to act as a last line of defense against a compromised or buggy renderer attempting to exploit the browser process. The core philosophy is to **terminate the offending process immediately** upon detecting any violation of the browser's assumptions about the data it should receive. This "fail-fast" approach is a critical security feature that prevents potential exploits.
+
+## 2. Core Concepts
+
+*   **Centralized Kill Switch**: The function `bad_message::ReceivedBadMessage()` is the central entry point for reporting a bad message. Calling this function is a declaration that the renderer has violated a security invariant and must be terminated.
+
+*   **Rich Enumerated Reasons**: The `BadMessageReason` enum, defined in `content/browser/bad_message.h`, provides a comprehensive, enumerated list of all possible reasons for a renderer termination. This is crucial for security analysis and bug tracking. When adding a new bad message check, a developer must add a new entry to this enum.
+
+*   **Robust Logging and Crash Reporting**: The mechanism is tightly integrated with Chromium's logging and crash reporting infrastructure.
+    *   **UMA Histograms**: The `Stability.BadMessageTerminated.Content` histogram is recorded, allowing developers to track the frequency of different bad message types in the wild.
+    *   **Crash Keys**: The `bad_message_reason` crash key is set before termination, embedding the specific reason for the kill directly into the crash report. This provides invaluable context for debugging.
+    *   **`DumpWithoutCrashing()`**: A key feature is the call to `base::debug::DumpWithoutCrashing()`. When a bad message is received on a thread other than the UI thread, this function is called to generate a crash dump of the *browser process* without actually killing it. This allows developers to analyze the browser's state at the exact moment of a potential exploit attempt.
+
+## 3. Security-Critical Logic & Implementation
+
+*   **`ReceivedBadMessage(RenderProcessHost* host, BadMessageReason reason)`**: This is the primary function. It immediately logs the bad message, sets the crash key, and calls `host->ShutdownForBadMessage()`. This version is called when the `RenderProcessHost` is readily available.
+
+*   **`ReceivedBadMessage(int render_process_id, BadMessageReason reason)`**: This version can be called from any thread. It performs the logging and generates the crash dump immediately, then posts a task to the UI thread (`ReceivedBadMessageOnUIThread`) to safely find the `RenderProcessHost` and terminate it. This ensures thread safety.
+
+*   **`RenderProcessHost::ShutdownForBadMessage()`**: This is the ultimate enforcement action. It terminates the renderer process with a specific exit code (`RESULT_CODE_KILLED_BAD_MESSAGE`), clearly indicating that the termination was due to a security violation, not a normal crash.
+
+## 4. How It's Used
+
+The `bad_message::ReceivedBadMessage()` function is called from hundreds of locations throughout the browser process, typically within Mojo and legacy IPC message handlers. It is invoked whenever a handler receives data that violates a critical assumption, such as:
+
+*   An invalid routing ID or object ID.
+*   Data that is inconsistent with the browser's internal state.
+*   A message that is not allowed for the process's current security context (e.g., a sandboxed frame attempting a privileged operation).
+*   Malformed data that could lead to memory corruption if processed further.
+
+By terminating the process immediately, the `bad_message` mechanism prevents the browser from acting on potentially malicious data, mitigating the risk of a sandbox escape.

--- a/security_notes/child_process_security_policy.md
+++ b/security_notes/child_process_security_policy.md
@@ -1,40 +1,49 @@
-# ChildProcessSecurityPolicy (`content/browser/child_process_security_policy_impl.h`)
+# ChildProcessSecurityPolicy (`content/browser/child_process_security_policy_impl.h`, `content/browser/child_process_security_policy_impl.cc`)
 
 ## 1. Summary
 
 The `ChildProcessSecurityPolicyImpl` is the kernel of Chromium's browser security model. It is a singleton that lives in the privileged browser process and acts as the central authority for granting and checking the capabilities of all less-privileged child processes (e.g., renderers). Its fundamental purpose is to enforce the principle of least privilege, ensuring that a child process only has the bare minimum rights needed to perform its tasks.
 
-This class is the primary enforcement point for **Site Isolation**, one of the most important security architectures in the browser. A bug in this class can easily lead to a complete breakdown of the browser's security boundaries.
+This class is the primary enforcement point for **Site Isolation**. A bug in this class can easily lead to a complete breakdown of the browser's security boundaries. This note is based on analysis of both the header and implementation files.
 
 ## 2. Core Concepts
 
-*   **Capability-Based Security:** Child processes start with almost no rights. The browser process must explicitly grant them capabilities on a case-by-case basis. This is in stark contrast to a model where a process starts with many rights that are later revoked.
+*   **Capability-Based Security:** Child processes start with almost no rights. The browser process must explicitly grant them capabilities on a case-by-case basis. This is managed by the internal `SecurityState` class, which holds all permissions for a given `child_id`.
 
-*   **The Process Lock:**
-    *   The most important concept is the **`ProcessLock`**. When a renderer process is created, it is typically "locked" to a specific site (e.g., `https://example.com`).
-    *   `ChildProcessSecurityPolicyImpl` stores this lock and uses it for all subsequent security decisions.
-    *   For example, if a process is locked to `site-a.com`, this policy will deny it the ability to commit a navigation to `site-b.com` or access `site-b.com`'s cookies. This is the core mechanism of Site Isolation.
+*   **The Process Lock (`ProcessLock`):**
+    *   The most important concept is the **`ProcessLock`**. When a renderer process is created, it is typically "locked" to a specific site (e.g., `https://example.com`) or marked as usable by any non-isolated site.
+    *   `ChildProcessSecurityPolicyImpl` stores this lock on a per-process basis and uses it for all subsequent security decisions.
+    *   The core enforcement logic is in `PerformJailAndCitadelChecks`, which compares the process's actual lock with the lock required for a requested origin. A mismatch results in a renderer kill.
 
 *   **Origin vs. Site Granularity:** The policy is sophisticated enough to handle isolation at different granularities.
     *   **Site Isolation (Default):** Processes are locked to a "site" (scheme + eTLD+1).
-    *   **Origin Isolation:** For sites that opt-in via the `Origin-Agent-Cluster` header or are configured via enterprise policy (`--isolate-origins`), the process lock is tightened to a full origin (scheme + host + port). This class contains the complex logic (`GetMatchingProcessIsolatedOrigin`) to determine the correct isolation scope for any given URL.
+    *   **Origin Isolation:** For sites that opt-in via the `Origin-Agent-Cluster` header or are configured via enterprise policy (`--isolate-origins`), the process lock is tightened to a full origin (scheme + host + port). The policy tracks these dynamic requests on a per-`BrowsingInstance` basis.
 
-*   **Dynamic Permissions:** Permissions are not static. They are granted dynamically as the user navigates. For example, when the user opens a file, `GrantReadFile()` is called to give the renderer process the temporary right to access *only that specific file*.
+*   **State Lifetime Management (`Handle`):** The policy uses a `Handle` class to manage the lifetime of a process's security state. This is a reference-counting mechanism that ensures the `SecurityState` for a process outlives the `RenderProcessHost` itself, preventing race conditions where security checks could be made on a process that is already being torn down.
 
 ## 3. Security-Critical Logic & Responsibilities
 
 This entire class is security-critical. A logic error in almost any public method could lead to a security boundary violation.
 
-*   **Commit and Access Checks:**
-    *   `CanCommitOriginAndUrl()`: This is arguably the most critical method. It is called before a navigation commits and decides if a given process is allowed to render a document from a specific origin. A flaw here could allow two different sites to share a process, completely breaking Site Isolation.
-    *   `CanAccessDataForOrigin()`: This method checks if a process can access stored data (cookies, localStorage, etc.) for an origin. It enforces that a process locked to `site-a.com` cannot read data from `site-b.com`. A bypass would lead to universal cross-site scripting (UXSS).
+*   **Core Security Checks (`CanAccess...` methods):**
+    *   **`CanCommitOriginAndUrl()`**: This is a critical gatekeeper for navigation. It verifies that a process is allowed to commit a document from a specific origin and URL. It performs multiple checks, including a call to `CanCommitURL`.
+    *   **`CanCommitURL()`**: This method performs scheme-based checks (e.g., disallowing most pseudo-schemes) and, crucially, calls `CanAccessMaybeOpaqueOrigin`.
+    *   **`CanAccessDataForOrigin()`**: This method checks if a process can access stored data (cookies, localStorage, etc.) for an origin. A bypass would lead to universal cross-site scripting (UXSS). This also funnels down to `CanAccessMaybeOpaqueOrigin`.
+    *   **`CanAccessMaybeOpaqueOrigin()` / `PerformJailAndCitadelChecks()`**: This is the heart of the enforcement. It calculates the `ProcessLock` required for the requested URL/origin and compares it against the process's actual `ProcessLock`. It correctly handles opaque origins, sandboxed frames, and PDF documents. If the check fails, the renderer process is terminated. This function uses detailed crash keys (`LogCanAccessDataForOriginCrashKeys`) to aid in debugging violations found in the wild.
 
 *   **Granting Capabilities:**
-    *   `Grant...()` methods (e.g., `GrantReadFile`, `GrantCommitURL`, `GrantWebUIBindings`): These methods are the entry points for giving power to a child process. A bug that grants an overly broad capability (e.g., access to `/` instead of `/path/to/file.txt`, or granting WebUI bindings to a normal web renderer) would be a critical vulnerability, often leading to a full sandbox escape.
+    *   `Grant...()` methods (e.g., `GrantReadFile`, `GrantCommitURL`, `GrantWebUIBindings`): These methods are the entry points for giving power to a child process. They are designed to be narrow. For example, `GrantRequestOfSpecificFile` grants access to a single file, not the entire `file://` scheme.
+    *   A bug that grants an overly broad capability (e.g., granting WebUI bindings to a normal web renderer) would be a critical vulnerability, often leading to a full sandbox escape.
 
-*   **State Management:** The policy maintains a `SecurityState` object for each child process. This state is constantly being updated as the user navigates. Race conditions or state confusion during process creation/destruction or complex navigation scenarios (e.g., redirects) are a major risk. The `Handle` inner class is an attempt to manage this by allowing the security state to outlive the `RenderProcessHost` it's associated with.
+*   **Dynamic Isolation State:**
+    *   The policy manages isolated origins that are not known at startup.
+    *   `AddFutureIsolatedOrigins()`: Used for enterprise policies or features like `Origin-Agent-Cluster` that apply to all future browsing sessions.
+    *   `AddCoopIsolatedOriginForBrowsingInstance()`: Used to enforce process isolation for a site that sent a Cross-Origin-Opener-Policy header, but only within the current `BrowsingInstance`.
 
-*   **Enforcing Web Platform Security Features:** This class is where many web platform security policies are actually enforced. For example, it checks if an origin is secure before granting access to powerful APIs and enforces restrictions related to `about:blank` and `data:` URLs.
+*   **Enforcing Web Platform Security Features:**
+    *   **Sandboxed Frames:** `IsAccessAllowedForSandboxedProcess()` enforces that sandboxed processes cannot access storage and can only host opaque origins.
+    *   **PDFs:** `IsAccessAllowedForPdfProcess()` enforces that PDF-hosting processes cannot access storage, even for the origin of the PDF itself.
+    *   **Blob/Filesystem URLs:** The policy correctly unwraps these URLs and performs checks on their inner origin.
 
 ## 4. Key Functions
 
@@ -42,10 +51,12 @@ This entire class is security-critical. A logic error in almost any public metho
 *   `LockProcess(...)`: Applies the `ProcessLock` to a process, defining its primary security boundary.
 *   `CanCommitOriginAndUrl(...)`: The central gatekeeper for navigation.
 *   `CanAccessDataForOrigin(...)`: The central gatekeeper for data access.
+*   `PerformJailAndCitadelChecks()` (internal): The core enforcement logic that compares the process lock to the requested origin's requirements.
 *   `Grant...()` / `Can...()` pairs: The mechanism for granting and checking specific capabilities.
 
 ## 5. Related Files
 
-*   `content/browser/renderer_host/render_process_host_impl.cc`: The class that owns a renderer process and is the primary client of `ChildProcessSecurityPolicyImpl`. It calls `Add`, `Remove`, and the various `Grant` methods.
-*   `content/browser/site_instance_impl.cc`: Represents a "site" and works closely with the security policy to determine process allocation.
+*   `content/browser/renderer_host/render_process_host_impl.cc`: The class that owns a renderer process and is the primary client of `ChildProcessSecurityPolicyImpl`.
+*   `content/browser/site_instance_impl.cc`: Works closely with the security policy to determine process allocation and the correct `ProcessLock`.
+*   `content/browser/process_lock.h`: Defines the `ProcessLock` class, which encapsulates the security principal a process is locked to.
 *   `content/public/browser/site_isolation_policy.h`: Defines the higher-level policies that are implemented by `ChildProcessSecurityPolicyImpl`.

--- a/security_notes/content/renderer/render_frame_impl.md
+++ b/security_notes/content/renderer/render_frame_impl.md
@@ -1,0 +1,90 @@
+# Security Analysis of content/renderer/render_frame_impl.cc
+
+## Overview
+
+`RenderFrameImpl` is a critical class in Chromium's rendering process, acting as the renderer-side representation of a single frame in a web page. It manages the frame's lifecycle, navigation, and communication with the browser process. Its complexity and central role make it a significant attack surface. This document outlines key security-relevant areas within `render_frame_impl.cc`.
+
+## 1. Navigation Handling
+
+`RenderFrameImpl` is central to handling navigations within the renderer process. Key methods involved are `BeginNavigation`, `CommitNavigation`, `CommitFailedNavigation`, and `CommitSameDocumentNavigation`.
+
+### 1.1 `BeginNavigation`
+- **Description**: Initiates a renderer-initiated navigation. It performs security checks, such as verifying if a navigation is allowed based on the frame's context (e.g., top-level vs. iframe, WebUI schemes).
+- **Security Considerations**:
+  - **URL Spoofing**: Incorrect handling of navigation parameters could lead to URL spoofing in the address bar if the browser process trusts the renderer's data too much.
+  - **Sandbox Bypass**: A compromised renderer could try to initiate navigations to privileged URLs (e.g., `file://`, `chrome://`). The browser process must validate all navigation requests from the renderer.
+  - **Cross-Origin Attacks**: The `initiator_origin` is crucial for security decisions. If a renderer can spoof this value, it could bypass security checks like the same-origin policy.
+
+### 1.2 `CommitNavigation`
+- **Description**: Commits a navigation that has been approved by the browser process. This involves setting up the new document, including its security context (origin, sandbox flags, etc.).
+- **Security Considerations**:
+  - **Incorrect Security Context**: Applying the wrong security properties (e.g., incorrect origin, sandbox flags, or permissions policy) during commit could lead to severe vulnerabilities. The renderer must correctly interpret the `CommitNavigationParams` from the browser.
+  - **Data URL Handling**: The method has special logic for handling `data:` URLs. Improper parsing or handling could lead to XSS or information disclosure. The `DecodeDataURL` function is of particular interest.
+
+### 1.3 `IsValidCommitUrl`
+- **Description**: This function validates URLs before they are sent to the browser process for commit. It checks for invalid URLs, excessively long URLs, and improper `about:` schemes.
+- **Security Considerations**:
+  - **Defense-in-Depth**: This is a good defense-in-depth mechanism to prevent the renderer from sending malicious or malformed URLs to the browser. However, the primary security boundary is in the browser process, which should perform its own validation.
+
+## 2. IPC Message Handling
+
+`RenderFrameImpl` exposes numerous Mojo interfaces to the browser process and other renderer components. These interfaces are a direct channel for potential attacks if not handled carefully.
+
+- **`OnAssociatedInterfaceRequest`**: This method routes incoming Mojo interface requests. An attacker could try to request interfaces they are not supposed to have access to.
+- **`Bind*` methods (e.g., `BindWebUI`, `BindAutoplayConfiguration`)**: These methods bind Mojo interfaces to implementations within `RenderFrameImpl`. The security of these bindings depends on the privileges of the requesting context. For example, `BindWebUI` should only be called for frames with WebUI bindings enabled.
+
+## 3. WebUI and Mojo JS Bindings
+
+- **`AllowBindings` and `EnableMojoJsBindings`**: These methods grant the frame special capabilities, such as the ability to interact with the browser through WebUI or Mojo JS.
+- **Security Considerations**:
+  - **Privilege Escalation**: Incorrectly granting these bindings to a web-facing renderer could allow a compromised renderer to execute privileged operations, leading to a full sandbox escape. The browser process must strictly control which frames get these bindings.
+
+## 4. Plugin and Content Handling
+
+- **`CreatePlugin`**: This method is responsible for creating plugin instances. Vulnerabilities in the plugin loading mechanism could be exploited.
+- **`CreateMediaPlayer`**: Handles the creation of media players. The interaction with media decoders and other media-related components can be a source of vulnerabilities.
+
+## 5. Cross-Origin Communication and Frame Management
+
+- **`CreateChildFrame`**: This method handles the creation of child frames (iframes).
+- **Security Considerations**:
+  - **Frame Tree Manipulation**: A compromised renderer could try to manipulate the frame tree in unexpected ways, such as creating frames with incorrect sandbox flags or origins.
+  - **Unique Name Generation**: The `unique_name_helper_` is used to generate unique names for frames. While this is not directly a security mechanism, predictable or manipulable names could potentially be abused in complex attack scenarios involving frame targeting.
+
+## 6. User Gesture Handling
+
+- **`DidChangeSelection` and `ConsumeTransientUserActivation`**: These methods are involved in handling user gestures, which are often required for privileged operations like popups or downloads.
+- **Security Considerations**:
+  - **Gesture Spoofing**: An attacker might try to spoof a user gesture to trigger a privileged action without user consent. The logic for tracking and consuming user activation must be robust.
+
+## 7. `NavigationClient` and its Role
+
+`NavigationClient` is a helper class that acts as the Mojo client for navigation-related communication from the browser process. It is tightly coupled with `RenderFrameImpl` and is responsible for forwarding navigation commands.
+
+- **`CommitNavigation` and `CommitFailedNavigation`**: These methods in `NavigationClient` directly call the corresponding methods in `RenderFrameImpl`, indicating that `NavigationClient` is the primary entry point for browser-driven navigation events.
+- **State Management**: The `was_initiated_in_this_frame_` member is a critical piece of state that tracks whether a navigation was initiated by the renderer. This distinction is important for security, as renderer-initiated navigations are generally less trusted than browser-initiated ones.
+- **Disconnection Handling**: The Mojo disconnection handler (`OnDroppedNavigation`) is crucial for ensuring that the renderer's state is cleaned up correctly if the browser cancels a navigation. Failure to do so could lead to state desynchronization vulnerabilities.
+
+## Summary of Potential Vulnerabilities
+
+- **Sandbox Escape**: A compromised renderer could exploit vulnerabilities in IPC handling or navigation to execute code in the browser process.
+- **Universal Cross-Site Scripting (UXSS)**: Incorrectly applying security contexts during navigation commit could allow a frame to access data from another origin.
+- **URL Spoofing**: If the browser process trusts the renderer's URL information, a compromised renderer could spoof the URL in the address bar.
+- **Information Disclosure**: Bugs in data handling (e.g., `data:` URLs, IPC messages) could lead to the disclosure of sensitive information.
+
+## 8. The Role of `RenderThreadImpl`
+
+`RenderThreadImpl` is the heart of the renderer process. It sets up and manages the global state for the entire process, including the creation and lifecycle of `RenderFrameImpl` instances. Its security relevance is foundational.
+
+- **Process Initialization**: `RenderThreadImpl::Init` is responsible for initializing the renderer process, including setting up Blink, registering URL schemes with specific security properties (`RegisterSchemes`), and establishing communication with the browser process. A flaw in this initialization could lead to a renderer process with incorrect security settings.
+- **Frame Creation and Routing**: `RenderThreadImpl::GenerateFrameRoutingID` is responsible for obtaining routing IDs for new frames from the browser. It uses a caching mechanism (`cached_frame_routing_`) to avoid synchronous IPCs. A bug in this caching logic could lead to routing ID reuse or other inconsistencies, potentially confusing the browser's frame management logic.
+- **GPU Channel and Resource Management**: It manages the connection to the GPU process (`EstablishGpuChannelSync`) and provides access to GPU factories (`GetGpuFactories`). A vulnerability in this area could be a vector for compromising the GPU process, which may have a less restrictive sandbox than the renderer.
+- **Global State**: It holds process-wide information, such as the user agent string and CORS-exempt headers, which are provided by the browser. The integrity of this information is critical for correct security enforcement in Blink.
+
+## 9. `AgentSchedulingGroup` and Frame Management
+
+The `AgentSchedulingGroup` is a crucial component that manages a collection of frames that can be scheduled together. It acts as an intermediary between the `RenderThreadImpl` and the individual `RenderFrameImpl` instances.
+
+- **Frame Creation**: `AgentSchedulingGroup::CreateView` and `AgentSchedulingGroup::CreateFrame` are the entry points for creating new views and frames within the group. This centralization of creation logic is important for ensuring that new frames are initialized with the correct security properties.
+- **IPC Routing**: The `AgentSchedulingGroup` owns the IPC channel (`channel_`) for the group and is responsible for routing associated Mojo interfaces to the correct `RenderFrameImpl`. The `GetAssociatedInterface` method is particularly important, as it looks up the correct frame to handle an incoming interface request.
+- **"UNSAFE" Pending Receiver Logic**: The code contains a comment marking the handling of pending receivers as "UNSAFE". This is a significant security concern, as it points to a potential race condition where an interface can be requested for a frame that has not yet been registered with the `AgentSchedulingGroup`. This could lead to dropped messages or state desynchronization between the browser and renderer, which are common sources of vulnerabilities.

--- a/security_notes/process_lock.md
+++ b/security_notes/process_lock.md
@@ -1,0 +1,47 @@
+# Security Note: ProcessLock (`content/browser/process_lock.h`)
+
+## 1. Summary
+
+`ProcessLock` is a security-critical class that represents the security principal of a `RenderProcessHost`. It is the central data structure used to enforce Site Isolation, defining what a renderer process is allowed to do. A `ProcessLock` is not an active locking mechanism (like a mutex), but rather a descriptor of the security context that a process is "locked" to.
+
+The `ChildProcessSecurityPolicyImpl` uses the `ProcessLock` of a process to make all of its critical access control decisions. An incorrect `ProcessLock` can lead to a complete breakdown of process-based security boundaries. This note is based on analysis of both the header and implementation files.
+
+## 2. Core Concepts
+
+*   **A Descriptor, Not an Active Lock**: `ProcessLock` is fundamentally a data-carrying class. It holds a `SiteInfo` object, which encapsulates all the security-relevant information about the principal the process is bound to.
+
+*   **Three States**: A `ProcessLock` can be in one of three states:
+    1.  **Invalid**: The initial state. The process is not yet associated with any `SiteInstance` and has no capabilities.
+    2.  **AllowAnySite**: The process can host documents from any site that does *not* require a dedicated process. This is for shared, non-isolated processes. These locks are created with `ProcessLock::CreateAllowAnySite`.
+    3.  **LockedToSite**: The process is strictly bound to a specific security principal (a site or origin) and cannot be used for any other. This is the cornerstone of Site Isolation. These locks are created with `ProcessLock::FromSiteInfo`.
+
+*   **Immutable Security Context**: Once a process is locked to a site, that lock cannot be changed to a different site or be made less restrictive. `ChildProcessSecurityPolicyImpl::SetProcessLock` contains `CHECK`s to enforce this invariant, preventing a process from being dangerously repurposed.
+
+*   **Derivation from `SiteInfo`**: The `ProcessLock` is almost entirely derived from a `SiteInfo`. The `SiteInfo` class contains the ground truth about a site's security properties, including its `AgentClusterKey` (which determines site vs. origin keying), sandbox flags, COOP/COEP isolation info, and more.
+
+## 3. Security-Critical Logic & Implementation
+
+*   **`ProcessLock::Create(isolation_context, url_info)`**: This is the primary static factory method. It creates a `SiteInfo` from the given `UrlInfo` and `IsolationContext`, and then uses that to construct the `ProcessLock`. The correctness of the `SiteInfo` creation logic is paramount, as any error there will result in an incorrect `ProcessLock`.
+
+*   **Comparison Operators (`operator==`, `operator<`)**: These operators are security-critical because they are used to determine if a process's existing lock is compatible with a requested navigation. The implementation in `process_lock.cc` carefully compares all relevant fields of the underlying `SiteInfo` (except for `site_url`, which can differ for effective URLs) to ensure that two locks are only considered equal if their security contexts are truly identical.
+
+*   **`IsLockedToSite()` and `AllowsAnySite()`**: These are the main predicates used by external code to query the state of the lock. Their implementation correctly checks the state of the internal `site_info_` member.
+
+*   **`ToString()`**: While not directly involved in enforcement, this method is crucial for security analysis and debugging. It provides a detailed, human-readable string representation of the lock's state, including its site, sandbox flags, and isolation status, which is invaluable when analyzing crash reports related to security violations.
+
+## 4. How It's Used in Enforcement
+
+The `ProcessLock` itself does not enforce anything. It is a data object that is used by other, more active security components:
+
+1.  **`RenderProcessHostImpl::SetProcessLock()`**: This method is called by a `SiteInstance` to apply the lock to its process.
+2.  **`ChildProcessSecurityPolicyImpl::LockProcess()`**: This method stores the `ProcessLock` in its internal `SecurityState` map for the given `child_id`.
+3.  **`ChildProcessSecurityPolicyImpl::CanAccess...` methods**: When a security check is needed (e.g., `CanAccessDataForOrigin`), the policy implementation retrieves the process's `ProcessLock` and compares it with the `ProcessLock` required for the requested resource. A mismatch results in a renderer kill.
+
+The security of the entire process model relies on the `ProcessLock` accurately representing the intended security context and the `ChildProcessSecurityPolicyImpl` correctly enforcing it.
+
+## 5. Related Files
+
+*   `content/browser/child_process_security_policy_impl.h`: The primary consumer of `ProcessLock` objects. It uses them to make all access control decisions.
+*   `content/browser/site_info.h`: The class that provides the underlying data for a `ProcessLock`.
+*   `content/browser/renderer_host/render_process_host_impl.h`: The object that owns a renderer process and has a `ProcessLock` applied to it.
+*   `content/browser/site_instance_impl.h`: The class that determines which `ProcessLock` a given navigation requires.

--- a/security_notes/render_frame_host.md
+++ b/security_notes/render_frame_host.md
@@ -1,0 +1,45 @@
+# Security Note: RenderFrameHost
+
+`RenderFrameHost` is a critical security boundary in Chromium, representing a single frame in the browser. It enforces security policies and isolates content from different origins. This note outlines the key security-related aspects of `RenderFrameHost`.
+
+## Lifecycle and State Management
+
+The `RenderFrameHost::LifecycleState` enum defines the state of a frame, which is crucial for security. The state determines what actions a frame can perform and prevents background pages from interfering with the user-facing page.
+
+- **`kActive`**: The frame is visible to the user and can execute scripts, display UI, and interact with the user.
+- **`kPrerendering`**: The frame is being prerendered and is not yet visible. It has limited capabilities and cannot display UI.
+- **`kInBackForwardCache`**: The frame is in the back-forward cache and is completely frozen. It cannot execute any code.
+- **`kPendingDeletion`**: The frame is being unloaded and will be deleted.
+
+The `IsActive()` method is the primary way to check if a frame is in the `kActive` state. This should always be checked before performing any action that could affect the user, such as displaying a prompt or accessing cross-document resources.
+
+## Sandboxing and Isolation
+
+`RenderFrameHost` enforces sandboxing policies to restrict the actions of a frame. The `IsSandboxed()` method can be used to check if a specific sandbox flag is active.
+
+- **`network::mojom::WebSandboxFlags`**: This enum defines the various sandbox flags that can be applied to a frame, such as `kNavigation` to prevent the frame from navigating the top-level window.
+
+## Cross-Origin Policies
+
+`RenderFrameHost` plays a central role in enforcing the Same-Origin Policy (SOP) and other cross-origin policies.
+
+- **`GetLastCommittedOrigin()`**: Returns the origin of the last committed document, which is used for security checks.
+- **`GetCrossOriginEmbedderPolicy()`**: Returns the Cross-Origin-Embedder-Policy (COEP) for the frame, which controls which cross-origin resources can be loaded.
+- **`GetPermissionsPolicy()`**: Returns the permissions policy for the frame, which controls access to powerful features like the camera or microphone.
+
+## Fenced Frames
+
+Fenced Frames are a new feature that allows embedding content from a different origin without granting it full access to the embedding page. `RenderFrameHost` provides several methods for managing Fenced Frames:
+
+- **`IsFencedFrameRoot()`**: Returns `true` if the frame is the root of a Fenced Frame tree.
+- **`IsNestedWithinFencedFrame()`**: Returns `true` if the frame is nested within a Fenced Frame.
+- **`IsUntrustedNetworkDisabled()`**: Returns `true` if the Fenced Frame has disabled untrusted network access, which is a key security feature of Fenced Frames. This prevents the frame from making arbitrary network requests and exfiltrating data.
+
+## JavaScript Execution
+
+`RenderFrameHost` provides several methods for executing JavaScript in the context of the frame. These methods are designed to be secure and prevent cross-origin script injection.
+
+- **`ExecuteJavaScript()`**: Executes JavaScript in the main world of the frame. This is restricted to chrome:// and devtools:// URLs.
+- **`ExecuteJavaScriptInIsolatedWorld()`**: Executes JavaScript in an isolated world, which provides a separate execution environment from the main world. This is the preferred way to execute scripts from extensions or other browser features.
+
+Understanding the security features of `RenderFrameHost` is essential for any developer working on Chromium. By properly using the APIs provided by `RenderFrameHost`, developers can ensure that their features are secure and do not introduce vulnerabilities.

--- a/security_notes/render_process_host_impl.md
+++ b/security_notes/render_process_host_impl.md
@@ -1,34 +1,32 @@
 # Security Notes: `content/browser/renderer_host/render_process_host_impl.cc`
 
-## File Overview
+## 1. File Overview
 
 This file implements the `RenderProcessHostImpl` class, which is one of the most security-critical components in the Chromium browser. It is the browser process's representation of a single sandboxed renderer process. It is responsible for the entire lifecycle of a renderer, including its creation, initialization, management, and termination. Every interaction between the browser's privileged process and the untrusted web content running in a renderer must pass through this object, making it the primary enforcement point for the browser's process isolation and sandbox security model.
 
-## Key Security Mechanisms and Patterns
+## 2. Key Security Mechanisms and Patterns
 
 ### 1. Process Creation and Sandboxing
 
 The `Init()` method orchestrates the creation of a new renderer process. This is the point where the sandbox is applied.
 
--   **`AppendRendererCommandLine()`**: This function constructs the command line for the new renderer process. It is a critical security function because it controls which sandbox policies and feature flags are enabled. It propagates a carefully curated list of switches from the browser process, preventing dangerous flags from being passed to the sandboxed process.
--   **`SandboxedProcessLauncherDelegate`**: The `RenderProcessHostImpl` uses a platform-specific `SandboxedProcessLauncherDelegate` (e.g., `RendererSandboxedProcessLauncherDelegateWin`) to configure the sandbox. This delegate is responsible for setting the sandbox policy (e.g., restricting filesystem or network access) before the process is launched.
--   **`--no-sandbox`**: The presence of the `--no-sandbox` flag is checked and propagated, effectively disabling the entire security boundary for that process. This is a critical switch for a security researcher to be aware of.
+-   **`AppendRendererCommandLine()`**: This function constructs the command line for the new renderer process. It is a critical security function because it controls which sandbox policies and feature flags are enabled. It propagates a carefully curated list of switches from the browser process, preventing dangerous flags from being passed to the sandboxed process. A bug here could weaken the sandbox.
+-   **`SandboxedProcessLauncherDelegate`**: The `RenderProcessHostImpl` uses a platform-specific `SandboxedProcessLauncherDelegate` (e.g., `RendererSandboxedProcessLauncherDelegateWin`) to configure the sandbox. This delegate is responsible for setting the sandbox policy before the process is launched.
+-   **`--no-sandbox`**: The presence of the `--no-sandbox` flag is checked and propagated, effectively disabling the entire security boundary for that process.
 
 ### 2. Site Isolation and Process Locking
 
 The `RenderProcessHostImpl` is the primary enforcer of the Site Isolation policy, which ensures that content from different websites runs in different processes.
 
 -   **`SetProcessLock()`**: This is the central function for applying a security "lock" to the process. It is called by the `SiteInstance` to associate the process with a specific `ProcessLock` (e.g., locked to `https://example.com`).
--   **`ChildProcessSecurityPolicyImpl`**: The `SetProcessLock` method delegates the actual enforcement to the `ChildProcessSecurityPolicyImpl`. This singleton object maintains the definitive record of what each renderer process is allowed to access.
+-   **`ChildProcessSecurityPolicyImpl`**: `SetProcessLock` delegates the actual enforcement to the `ChildProcessSecurityPolicyImpl`. This singleton object maintains the definitive record of what each renderer process is allowed to access.
 -   **`NotifyRendererOfLockedStateUpdate()`**: After a lock is applied, this method notifies the renderer process of its new security context. This is crucial for features like Cross-Origin-Isolated contexts, as it tells the renderer whether it is allowed to use powerful APIs like `SharedArrayBuffer`.
-
-A bug in the process locking logic could allow a renderer to bypass Site Isolation, giving it access to data from other sites.
 
 ### 3. Secure IPC and Interface Binding
 
 The `RenderProcessHostImpl` acts as the broker for all Mojo IPC interfaces requested by the renderer. It is the gatekeeper that determines what capabilities a renderer has.
 
--   **`BindReceiver()` and `OnBindHostReceiver()`**: These methods handle requests from the renderer to bind a Mojo interface. The `RenderProcessHostImpl` maintains a registry of allowed interfaces. If a renderer requests an interface it is not permitted to have (e.g., a privileged filesystem interface), the request is rejected.
+-   **`OnBindHostReceiver()` / `RegisterMojoInterfaces()`**: These methods handle requests from the renderer to bind a Mojo interface. The `RenderProcessHostImpl` maintains a registry of allowed interfaces. If a renderer requests an interface it is not permitted to have (e.g., a privileged filesystem interface), the request is rejected, often leading to a `bad_message` kill.
 -   **Security Implication**: The set of interfaces exposed to a renderer defines its attack surface. By carefully controlling which interfaces are available, the browser limits the potential damage a compromised renderer can cause. Any vulnerability that allows a renderer to bind an unauthorized interface would be a critical sandbox escape.
 
 ### 4. Process Lifecycle and Shutdown Security
@@ -36,12 +34,21 @@ The `RenderProcessHostImpl` acts as the broker for all Mojo IPC interfaces reque
 The `RenderProcessHostImpl` manages the renderer's lifecycle, including its termination. This is critical for both stability and security.
 
 -   **`ShutdownForBadMessage()`**: If the browser receives a malformed or unexpected IPC message from the renderer, it calls this function. This immediately terminates the renderer process, assuming it is malicious or corrupt. This is a critical defense against a compromised renderer attempting to exploit the browser process via IPC.
--   **`Cleanup()`**: This method is called when a renderer process is no longer needed (e.g., all of its frames have been closed). It manages a complex set of "keep-alive" reference counts (`keep_alive_ref_count_`, `worker_ref_count_`, etc.).
--   **Security Implication**: The keep-alive logic is extremely security-sensitive. A bug that causes a reference count to be leaked could prevent a process from being shut down, leading to resource exhaustion. Conversely, a bug that causes a premature `Cleanup()` while some part of the browser still holds a reference to the process could lead to a use-after-free vulnerability, which is often exploitable. The `fast_shutdown_started_` and `deleting_soon_` flags are used to prevent re-entrant calls and other race conditions during this delicate process.
+-   **`Cleanup()` and Keep-Alive Logic**: This method is called when a renderer process is no longer needed. It manages a complex set of "keep-alive" reference counts (`keep_alive_ref_count_`, `worker_ref_count_`, `shutdown_delay_ref_count_`).
+    -   **Security Implication**: The keep-alive logic is extremely security-sensitive. A bug that causes a reference count to be leaked could prevent a process from being shut down, leading to resource exhaustion. Conversely, a bug that causes a premature `Cleanup()` while some part of the browser still holds a reference to the process could lead to a use-after-free vulnerability, which is often exploitable. The `fast_shutdown_started_` and `deleting_soon_` flags are used to prevent re-entrant calls and other race conditions during this delicate process.
 
-### 5. URL Request Filtering
+### 5. Process Reuse Policy
 
--   **`FilterURL()`**: Before a renderer is allowed to navigate or request a resource, the URL is passed through this function. It delegates to `ChildProcessSecurityPolicyImpl::CanRequestURL` to check if the process has the right to access that URL. This prevents a renderer locked to `site-a.com` from requesting resources from `site-b.com`, enforcing the Site Isolation security model at the network request level.
+To optimize performance, the browser attempts to reuse existing renderer processes. This logic is also security-critical.
+
+-   **`IsSuitableHost()`**: This is the core function for determining if an existing process can be used for a new `SiteInstance`. It performs numerous checks:
+    -   The `BrowserContext` must match.
+    -   Guest and non-guest processes cannot be mixed.
+    -   JIT, PDF, and V8 optimization flags must match.
+    -   The `StoragePartition` must be the same.
+    -   Most importantly, it checks that the `ProcessLock` of the existing host is compatible with the requirements of the new site. An unlocked process cannot be used for a site that requires isolation, and a locked process cannot be used for anything else.
+-   **`FindReusableProcessHostForSiteInstance()`**: This function uses the `SiteProcessCountTracker` to find an existing process that is already hosting content for, or expecting a navigation to, the same site. This is a performance optimization, but a bug in `IsSuitableHost` could make this dangerous.
+-   **Memory Thresholds**: The reuse policy also considers the memory footprint of a process (`GetPrivateMemoryFootprint()`) and the number of frames it hosts, preventing a process from being reused if it's already consuming too many resources. This is a defense against resource exhaustion attacks.
 
 ## Summary of Security Posture
 
@@ -49,7 +56,7 @@ The `RenderProcessHostImpl` is the citadel of browser security. It is the centra
 
 -   **Security Model**: It is a classic reference monitor, mediating all interactions between the untrusted renderer and the privileged browser.
 -   **Primary Risks**: Given its complexity and central role, it is a high-value target for security researchers.
-    -   **Process Reuse Bugs**: Logic errors in `IsSuitableHost` could lead to a process being reused for a site it shouldn't have access to.
+    -   **Process Reuse Bugs**: Logic errors in `IsSuitableHost` could lead to a process being reused for a site it shouldn't have access to, breaking Site Isolation.
     -   **Lifecycle and Shutdown Bugs**: Errors in the keep-alive or cleanup logic are a potential source of use-after-free vulnerabilities.
     -   **IPC Broker Bypass**: Any vulnerability that allows a renderer to bind a privileged interface would be a full sandbox escape.
     -   **Incorrect Sandbox Configuration**: A bug in how the command line is constructed or how the sandbox delegate is configured could lead to a weakened or nonexistent sandbox.

--- a/security_notes/site_instance.md
+++ b/security_notes/site_instance.md
@@ -1,51 +1,73 @@
-# SiteInstance (`content/browser/site_instance_impl.h`)
+# SiteInstance (`content/browser/site_instance_impl.h`, `content/browser/site_instance_impl.cc`)
 
 ## 1. Summary
 
 The `SiteInstance` is one of the most important security-critical classes in the browser process. It represents a "unit of privilege" for a collection of documents or workers. Its primary responsibility is to make process model decisions: for any given navigation, the `SiteInstance` determines which renderer process is allowed to host the content. It is the central component that makes **Site Isolation** possible.
 
-A logical flaw in this class can lead to a complete breakdown of process-based security boundaries, allowing documents from different websites to share a process, which is a critical vulnerability.
+A logical flaw in this class can lead to a complete breakdown of process-based security boundaries, allowing documents from different websites to share a process, which is a critical vulnerability. This note is based on analysis of both the header and implementation files.
 
 ## 2. Core Concepts
 
-*   **The "Site" as a Security Principal:** The fundamental concept is the "site," which is a security principal typically defined by the URL's scheme and its effective Top-Level Domain plus one (eTLD+1). For example, `https://mail.google.com` and `https://docs.google.com` both belong to the `https://google.com` site. The `SiteInstance` uses a `SiteInfo` object to encapsulate this principal.
+*   **The "Site" as a Security Principal:** The fundamental concept is the "site," a security principal typically defined by the URL's scheme and its effective Top-Level Domain plus one (eTLD+1). For example, `https://mail.google.com` and `https://docs.google.com` both belong to the `https://google.com` site. The `SiteInstance` uses a `SiteInfo` object to encapsulate this principal.
 
 *   **Process Model Decisions:** The main job of a `SiteInstance` is to be the key for process allocation.
     *   When a new document needs to be rendered, the browser looks up or creates a `SiteInstance` for its destination URL.
-    *   This `SiteInstance` is then used to find a suitable `RenderProcessHost`.
-    *   If a process already exists for that `SiteInstance`'s site, it will be reused.
-    *   If not, a new process will be created and will be **locked** to that `SiteInstance`'s site via the `ChildProcessSecurityPolicy`.
+    *   This `SiteInstance` is then used to find a suitable `RenderProcessHost` via `GetOrCreateProcess()`.
+    *   If a process already exists for that `SiteInstance`'s site (and it's a process-per-site model), it will be reused.
+    *   If not, a new process will be created and will be **locked** to that `SiteInstance`'s site.
 
 *   **Relationship to `BrowsingInstance`:**
     *   A `BrowsingInstance` is a collection of related browsing contexts (e.g., a tab and its popups) that can synchronously script each other.
     *   A `SiteInstance` lives *within* a `BrowsingInstance`. A single `BrowsingInstance` can contain multiple `SiteInstance`s, one for each distinct site that has been visited.
     *   The `SiteInstance` is what enforces the process-level separation *between* sites within the same `BrowsingInstance`.
 
-*   **Effective URLs:** The class uses the concept of an "effective URL" (`GetEffectiveURL`). This is a security mechanism that allows the browser to treat certain URLs as if they belong to a different security origin. For example, a `chrome-native://` URL might have an effective URL of a privileged `chrome://` origin, ensuring it is always loaded in a highly-privileged process, not a web-content process.
+*   **Effective URLs:** The class uses the concept of an "effective URL" (`GetEffectiveURL`). This is a security mechanism that allows the browser to treat certain URLs as if they belong to a different security origin. The logic is delegated to the embedder via `ContentBrowserClient::GetEffectiveURL`, meaning embedders like Chrome can have custom rules (e.g., for hosted apps).
 
 ## 3. Security-Critical Logic & Vulnerabilities
 
-*   **Site Calculation:** The most critical logic is the calculation of the site from a URL (`SetSite`, `IsSameSiteWithURL`). A bug here is catastrophic. If two distinct websites (e.g., `https://example.com` and `https://evil.com`) were incorrectly calculated to be the same site, they would be placed in the same renderer process, completely defeating Site Isolation and allowing for universal cross-site scripting.
+### Process Locking and Enforcement
 
-*   **Process Reuse and Selection:** The logic for deciding whether to reuse an existing process or create a new one is security-critical. A bug that causes a `SiteInstance` for `site-a.com` to incorrectly reuse a process that is locked to `site-b.com` would violate the process model. `RequiresDedicatedProcess()` and the internal process reuse policies are key here.
+*   **`LockProcessIfNeeded()`**: This is the primary enforcement mechanism. When a `SiteInstance` is assigned a process, this function sets a `ProcessLock` on the `RenderProcessHost`.
+    *   The lock is created from the `SiteInfo` (`ProcessLock::FromSiteInfo`).
+    *   It prevents the process from being used by other sites that require isolation.
+    *   A `NOTREACHED()` crash will be triggered if code attempts to assign a site to a process that is already locked to an incompatible site, which is a critical defense-in-depth check.
 
-*   **The Default `SiteInstance`:** For sites that do not require a dedicated process (e.g., on platforms where Site Isolation is not fully enabled, or for `about:blank`), they are often grouped into a "default" `SiteInstance`. A bug that incorrectly classifies a site that *should* be isolated and places it in the default process would be a major security issue.
+*   **`ShouldUseProcessPerSite()` / `SiteInfo::RequiresDedicatedProcess()`**: These functions contain the core logic for deciding if a site *must* be isolated. A bug here could cause a sensitive site to be placed in a shared process. This decision considers:
+    *   The global Site Isolation policy (`SiteIsolationPolicy::IsSiteIsolationEnabled`).
+    *   Whether the URL's scheme is standard.
+    *   Dynamically isolated origins (e.g., via `Origin-Agent-Cluster` or COOP).
+    *   WebUI schemes.
 
-*   **State Management during Navigation:** The state of a `SiteInstance` (specifically, its `SiteInfo`) can be set lazily. During a complex navigation with redirects, it's critical that the final `SiteInfo` is determined correctly and that there's no state confusion that could lead to an incorrect process placement.
+### Site and Origin Comparison
 
-*   **Guest and Sandboxed Contexts:** The class has special handling for `<webview>` guests (`IsGuest()`) and sandboxed frames (`IsSandboxed()`). These contexts have different storage and permission models, and a bug that confuses a guest `SiteInstance` with a regular one could lead to a sandbox escape or information disclosure.
+*   **`IsSameSite()`**: This static method is the ground truth for comparing two URLs. A bug here is catastrophic. It correctly handles multiple complex cases:
+    *   It respects `should_compare_effective_urls`.
+    *   It checks for scheme equality.
+    *   It uses `net::registry_controlled_domains::SameDomainOrHost` for the primary comparison.
+    *   Crucially, it checks against the `ChildProcessSecurityPolicy` for dynamically isolated origins. If either URL matches an isolated origin, the comparison is promoted from site-level to origin-level.
+
+### Special Contexts and Process Reuse
+
+*   **The Default `SiteInstance`**: For sites that do not require a dedicated process, they are often grouped into a "default" `SiteInstance`.
+    *   The logic in `CanBePlacedInDefaultSiteInstanceOrGroup()` determines what can go into this shared context. Notably, `file://` URLs are excluded to prevent the default process from accumulating dangerous file access grants.
+    *   A bug that incorrectly classifies a site that *should* be isolated and places it in the default process would be a major security issue.
+
+*   **Guest and Sandboxed Contexts**: The class has special handling for `<webview>` guests (`IsGuest()`) and sandboxed frames (`IsSandboxed()`). These contexts have different storage and permission models, and a bug that confuses a guest `SiteInstance` with a regular one could lead to a sandbox escape or information disclosure.
+
+*   **Fenced Frames**: The static method `CreateForFencedFrame()` shows the special setup for this new context. A new `BrowsingInstance` is created to provide isolation, but crucially, the new `SiteInstance` may initially reuse the embedder's process to avoid jank before the fenced frame navigates. The actual process isolation occurs upon navigation within the fenced frame.
 
 ## 4. Key Functions
 
-*   `Create...()`: The static methods for creating new `SiteInstance`s, which also create a new `BrowsingInstance`.
+*   `Create...()`: The static methods for creating new `SiteInstance`s. `CreateForUrlInfo` is a key entry point.
 *   `GetRelatedSiteInstance(...)`: The primary method used during navigation to find or create a `SiteInstance` for a destination URL *within the same `BrowsingInstance`*.
-*   `GetSiteInfo()`: Returns the security principal (`SiteInfo`) for this instance. This is the ground truth for security decisions.
-*   `GetOrCreateProcess()`: The method that triggers the actual process selection or creation based on the `SiteInstance`'s state.
-*   `IsSameSiteWithURL()`: The core comparison function that determines if a URL belongs to the same site as the `SiteInstance`.
+*   `GetOrCreateProcess()`: The method that triggers the actual process selection or creation based on the `SiteInstance`'s state and reuse policy.
+*   `SetSite()` / `SetSiteInfoInternal()`: These methods assign the security principal (`SiteInfo`) to the `SiteInstance`, which is a critical, one-time operation.
+*   `LockProcessIfNeeded()`: Applies the `ProcessLock` to the renderer process, enforcing the security boundary.
 
 ## 5. Related Files
 
-*   `content/browser/child_process_security_policy_impl.h`: The `SiteInstance` determines the policy (e.g., "this process is for `https://example.com`"), and the `ChildProcessSecurityPolicy` enforces it.
-*   `content/browser/renderer_host/render_process_host_impl.h`: The class representing the actual OS process that a `SiteInstance` is assigned to.
+*   `content/browser/child_process_security_policy_impl.h`: The `SiteInstance` determines the policy (e.g., "this process is for `https://example.com`"), and the `ChildProcessSecurityPolicy` enforces it and tracks dynamically isolated origins.
+*   `content/browser/renderer_host/render_process_host_impl.h`: The class representing the actual OS process that a `SiteInstance` is assigned to. It holds the `ProcessLock`.
 *   `content/browser/browsing_instance.h`: The owner and manager of a collection of `SiteInstance`s.
 *   `content/browser/site_info.h`: The data structure that encapsulates the "site" principal.
+*   `content/public/browser/content_browser_client.h`: Allows the embedder to override key security logic, such as effective URL resolution.


### PR DESCRIPTION
This commit introduces initial security notes for `RenderFrameImpl`, a critical component in the Chromium renderer process. The analysis covers `render_frame_impl.cc` and its interactions with `navigation_client.cc`, `render_thread_impl.cc`, and `agent_scheduling_group.cc`.

The new security notes document several key areas:
- The central role of `RenderFrameImpl` in navigation handling, IPC processing, and security context management.
- The function of `NavigationClient` as the Mojo entry point for browser-initiated navigations.
- The foundational responsibilities of `RenderThreadImpl` in process initialization, frame creation, and resource management, including the GPU channel.
- The frame management and IPC routing logic of `AgentSchedulingGroup`, highlighting a potential race condition in its handling of pending Mojo receivers.

The notes are located in `security_notes/content/renderer/render_frame_impl.md`.

During this work, I encountered issues with the `chromium-helper search` and `grep` tools, which were unresponsive. I adapted by using `chromium-helper ls` to explore the file system and manually identify relevant files, which allowed me to proceed with the analysis.