### PR TITLE
I have analyzed `p2p_transport_channel.cc` and documented my findings…

### DIFF
--- a/security_notes/base_allocator_partition_allocator_src_partition_alloc_page_allocator.md
+++ b/security_notes/base_allocator_partition_allocator_src_partition_alloc_page_allocator.md
@@ -1,0 +1,33 @@
+# Security Analysis of `page_allocator.cc`
+
+This document provides a security analysis of the `page_allocator.cc` file. This component is the lowest level of the PartitionAlloc system, acting as the direct interface with the operating system's virtual memory APIs (e.g., `mmap` on POSIX, `VirtualAlloc` on Windows). Its primary role is to reserve, commit, and protect large regions of virtual memory. The security of the entire allocator depends on the correctness and robustness of this foundational layer.
+
+## 1. Address Space Layout Randomization (ASLR)
+
+The page allocator is responsible for implementing PartitionAlloc's own high-entropy ASLR, which is a critical defense against exploits that rely on predictable memory layouts.
+
+-   **`AllocPagesWithAlignOffset` (line 193):** This is the core allocation function. It does not simply ask the OS for memory; it employs a sophisticated strategy to ensure allocations are placed at unpredictable addresses.
+-   **Randomized Allocation Strategy:** The function first attempts to allocate memory at a random address chosen by `GetRandomPageBase()`. If this fails (e.g., because the address is already in use), it doesn't give up. Instead, it allocates a *larger* region of memory than requested and then uses `TrimMapping` to carve out a correctly aligned chunk from within that larger region, freeing the unused portions.
+-   **Security Implication:** This two-phase approach (randomized placement followed by over-allocation and trimming) is a **powerful ASLR implementation**. It makes it significantly harder for an attacker to predict the location of key memory regions, which is a prerequisite for many exploitation techniques. The security depends on the quality of the randomness provided by `GetRandomPageBase`.
+
+## 2. Guarding and Memory Protection
+
+A primary goal of the page allocator is to create "guard regions" of inaccessible memory around allocations to prevent buffer overflows from corrupting adjacent memory.
+
+-   **`TrimMapping` (line 94):** This is the **key security function** for creating guard regions. After a chunk of memory is carved out from a larger reservation, this function is responsible for decommitting or releasing the unused "slack" memory at the beginning and end of the chunk.
+-   **Security Implication:** This ensures that the memory immediately surrounding a large allocation is unmapped. A classic linear buffer overflow will therefore not silently corrupt a neighboring allocation; instead, it will hit an unmapped page, resulting in an immediate and safe process crash. This is a fundamental defense against heap exploitation.
+
+-   **`PageAccessibilityConfiguration`:** All memory allocation and protection-change functions (`AllocPages`, `SetSystemPagesAccess`, `DecommitSystemPages`) operate on this enum. This provides a strongly-typed, platform-independent way to specify memory permissions (`kReadWrite`, `kReadExecute`, `kInaccessible`, etc.).
+-   **Security Implication:** This is the mechanism that enforces Data Execution Prevention (DEP) at the lowest level. By ensuring that memory pages are never simultaneously writable and executable, it provides a fundamental defense against attacks that write shellcode into a data buffer and then execute it.
+
+## 3. Secure Failure Handling
+
+-   **`TerminateAnotherProcessOnCommitFailure` (Windows, line 462):** This function implements a sophisticated defense against out-of-memory (OOM) conditions. On Windows, if committing memory fails, this mechanism can terminate a designated other process (typically the browser process) to free up system resources, rather than allowing the current sandboxed process to crash in a potentially exploitable OOM state.
+-   **Security Implication:** This is an advanced reliability and security feature. It makes the browser more resilient to memory-exhaustion DoS attacks and prevents the system from entering a state where low memory could cause other security mechanisms to fail.
+
+## Summary of Potential Security Concerns
+
+1.  **Kernel Vulnerabilities:** As the direct interface to the OS, the page allocator's security is fundamentally dependent on the security of the underlying kernel's virtual memory implementation. Every syscall it makes (`mmap`, `VirtualAlloc`, `mprotect`, `VirtualProtect`) is a potential vector for an attacker to exploit a kernel vulnerability. The security of this layer is only as strong as the OS kernel it runs on.
+2.  **Complexity of `TrimMapping`:** The logic for calculating offsets and trimming slack space is complex and involves careful pointer arithmetic. A bug in this function could lead to smaller-than-intended guard regions or, in a worst-case scenario, could decommit the wrong memory, leading to a crash or a potentially exploitable memory corruption.
+3.  **Race Conditions in Reservation:** The global address space reservation (`s_reservation_address`) is protected by a lock (`g_reserve_lock`). A bug in this locking, such as a code path that manipulates the reservation without acquiring the lock, could lead to a critical race condition between two threads, potentially corrupting the allocator's view of the address space.
+4.  **ASLR Predictability:** The strength of the ASLR provided by this component depends entirely on the quality of the random numbers provided by `GetRandomPageBase`. If the random source were ever to become weak or predictable, the effectiveness of this key defense would be compromised.

--- a/security_notes/base_allocator_partition_allocator_src_partition_alloc_partition_alloc.md
+++ b/security_notes/base_allocator_partition_allocator_src_partition_alloc_partition_alloc.md
@@ -1,0 +1,28 @@
+# Security Analysis of `partition_alloc.h`
+
+This document provides a security analysis of the `partition_alloc.h` header file. This file serves as the top-level entry point for the PartitionAlloc system but delegates most of its logic to the `PartitionRoot` class. The most critical security aspect of this file is not its code, but the extensive comments that lay out the fundamental security and memory-safety philosophy of the entire allocator, especially concerning Memory Tagging Extensions (MTE).
+
+## 1. The "Slot" vs. "Object" Security Boundary
+
+The core security principle articulated in this file is the strict separation between two concepts: the "slot" and the "object."
+
+-   **Slot:** An internal, indivisible unit of allocation managed by PartitionAlloc. It is represented as a raw address (`uintptr_t`) and is explicitly **not** MTE-tagged. This allows the allocator to perform necessary pointer arithmetic on its internal metadata.
+-   **Object:** The user-facing region of memory returned by `malloc()` or `new`. This memory is contained *within* a slot. It is represented as a typed pointer (e.g., `void*`) and **is** MTE-tagged.
+
+-   **Security Implication:** This separation creates a **critical security boundary**. The MTE tag on the "object" ensures that any access by application code is checked by the hardware. An attacker who manages to corrupt a pointer can only access memory within the valid, tagged bounds of that object. They cannot access the raw, untagged "slot" memory, which contains sensitive allocator metadata like freelist pointers. This prevents an entire class of heap exploitation techniques where an attacker overflows an object to corrupt the allocator's internal metadata.
+
+## 2. Secure Transitions Between Worlds
+
+The "housekeeping rules" mandate the use of specific functions to transition between the tagged "object" world and the untagged "slot" world.
+
+-   **`PartitionRoot::ObjectToSlotStart()` and `PartitionRoot::SlotStartToObject()`:** These functions are the designated, secure gateways. They are responsible for not only calculating the offset between the slot and the object but, more importantly, for correctly **adding or stripping the MTE tag** during the conversion.
+
+-   **Discouragement of Unsafe Primitives:** The comments explicitly warn against the direct use of lower-level primitives like `UntagPtr()` or `reinterpret_cast`.
+
+-   **Security Implication:** This establishes a secure read/write barrier for the allocator itself. By forcing all conversions through these specific functions, the design ensures that MTE tags are managed correctly and consistently. A bug in this logic, or a developer failing to use these gateways, could lead to tag confusion or the accidental exposure of an untagged pointer to user code, which would create a vulnerability. This disciplined approach is essential for maintaining the integrity of the MTE-based security guarantees.
+
+## Summary of Potential Security Concerns
+
+1.  **Correctness of the Gateway Functions:** The security of the slot/object boundary depends entirely on the flawless implementation of the `ObjectToSlotStart` and `SlotStartToObject` functions. A bug in their MTE-tagging logic would undermine the entire model.
+2.  **Developer Discipline:** The model relies on all PartitionAlloc developers adhering to the "housekeeping rules." Any deviation, such as using `reinterpret_cast` instead of the approved gateway functions, could introduce a security vulnerability.
+3.  **Security of `PartitionRoot`:** This file establishes the high-level security philosophy, but the actual implementation of all memory management, metadata protection (like freelist pointer poisoning), and security checks resides within the `PartitionRoot` class. The overall security of the allocator depends on the correctness of that much larger and more complex component. This header correctly identifies `PartitionRoot` as the place where the core logic lives.

--- a/security_notes/base_allocator_partition_allocator_src_partition_alloc_partition_root.md
+++ b/security_notes/base_allocator_partition_allocator_src_partition_alloc_partition_root.md
@@ -1,0 +1,40 @@
+# Security Analysis of `partition_root.cc`
+
+This document provides a security analysis of the `PartitionRoot` class, which is the core engine of the PartitionAlloc memory allocator. This class implements the central allocation logic and is responsible for many of PartitionAlloc's most critical security features. Its design aims to mitigate common heap-based memory corruption vulnerabilities.
+
+## 1. Use-After-Free Mitigation (BackupRefPtr)
+
+The most significant security feature implemented in `PartitionRoot` is its support for BackupRefPtr (BRP), a powerful defense against use-after-free (UAF) vulnerabilities.
+
+-   **Quarantine on Free (`QuarantineForBrp`, line 1825):** When an object in a BRP-enabled partition is freed, it is not immediately returned to the freelist. Instead, it is placed in a quarantine and its memory is overwritten with a poison value (`kQuarantinedByte`). This makes it highly probable that any attempt to use a dangling pointer to this object will result in an immediate and safe crash, rather than being exploitable.
+-   **Pointer Validation (`IsPtrWithinSameAlloc`, line 72):** When a `raw_ptr` with BRP enabled is dereferenced, this function is called. It uses the pointer's address to look up its corresponding slot metadata and verifies that the pointer still falls within the valid bounds of its original allocation. This is a **critical security check** that prevents a dangling pointer from being used to access memory outside of its original allocation, even if that memory has been reallocated for a new object.
+-   **In-Slot Reference Counting:** The BRP mechanism relies on a reference count stored in the metadata for each slot. This count tracks the number of `raw_ptr` instances pointing to the allocation. An allocation can only be truly freed and re-used when its BRP ref-count drops to zero, providing strong temporal memory safety.
+
+## 2. Buffer Overflow Detection
+
+PartitionAlloc employs a classic and effective technique to detect buffer overflows.
+
+-   **Security Cookies (`USE_PARTITION_COOKIE`):** When enabled, a secret "cookie" value is written into the memory immediately following the user-visible portion of an allocation.
+-   **`CheckMetadataIntegrity` (line 1839):** This function, which can be called at various points (e.g., during free), verifies the integrity of this cookie. If a buffer overflow has occurred, it will have corrupted the cookie. The `PartitionCookieCheckValue` call (line 1888) will detect this mismatch and immediately crash the process.
+-   **Security Implication:** This turns a potentially silent and exploitable heap overflow into a noisy and non-exploitable crash. The security depends on the cookie value being unpredictable to an attacker.
+
+## 3. Metadata Protection
+
+Protecting the allocator's own internal metadata (like freelist pointers) from corruption is paramount.
+
+-   **In-Slot Metadata:** Critical metadata, including BRP ref-counts and freelist pointers, is stored within the allocation slot but *outside* the user-visible object area.
+-   **MTE and the Slot/Object Boundary:** As described in the `partition_alloc.h` analysis, the user-visible "object" is MTE-tagged, while the surrounding "slot" containing the metadata is not directly accessible. This hardware-enforced boundary (on supported platforms) prevents an attacker from using an object pointer to directly read or write the allocator's internal metadata. The security of this mechanism is fundamental.
+
+## 4. Partitioning as a Security Primitive
+
+The entire design is built around the concept of `PartitionRoot`, where each partition is an isolated heap.
+
+-   **Type Isolation:** Different types of objects (e.g., DOM nodes, strings, buffers) are allocated in different partitions. This is a powerful security feature that prevents a vulnerability involving an object of one type from being used to corrupt an object of a different type. For example, an overflow in a string cannot be used to overwrite a vtable pointer in a C++ object if they are in different partitions.
+-   **Thread Isolation:** The code contains logic for thread-isolated partitions, providing a defense against cross-thread attacks where a vulnerability on one thread is used to corrupt memory used by another.
+
+## Summary of Potential Security Concerns
+
+1.  **Complexity:** The `PartitionRoot` is extremely complex. It manages multiple allocation paths (buckets, direct map), thread caches, and complex memory reclamation logic (`PartitionPurgeSlotSpan`). A bug in any of these areas, especially one that could lead to state confusion, could potentially be exploited to undermine the security guarantees.
+2.  **BRP and Cookie Bypass:** The security of the BRP and cookie mechanisms depends on them being applied consistently. Any allocation path that accidentally bypasses the BRP quarantine or fails to place a cookie would create a weak point in the allocator's defenses.
+3.  **Freelist Pointer Integrity:** While protected by the slot/object boundary, the freelist pointers themselves are a high-value target. An attacker who finds a way to write to the untagged slot memory could potentially corrupt a freelist pointer to gain control over the allocator's behavior, leading to a "write-what-where" primitive. The security of the allocator hinges on the inviolability of this boundary.
+4.  **`raw_ptr` Adoption:** The effectiveness of BRP depends on the complete adoption of `raw_ptr` throughout the Chromium codebase, replacing all raw C++ pointers to PartitionAlloc-managed objects. Any remaining raw pointer is a potential UAF vulnerability that BRP cannot protect against.

--- a/security_notes/base_allocator_partition_allocator_src_partition_alloc_thread_cache.md
+++ b/security_notes/base_allocator_partition_allocator_src_partition_alloc_thread_cache.md
@@ -1,0 +1,33 @@
+# Security Analysis of `thread_cache.cc`
+
+This document provides a security analysis of the `thread_cache.cc` file. This file contains the core implementation of PartitionAlloc's per-thread caching mechanism. While designed as a performance optimization, its implementation has critical security implications related to thread safety, memory lifetime, and protection against freelist corruption.
+
+## 1. Thread-Local Storage and State Management
+
+The core security guarantee of the `ThreadCache` is that it is strictly confined to a single thread. This is enforced through Thread-Local Storage (TLS).
+
+-   **TLS Implementation:** The implementation uses a platform-agnostic `PartitionTlsKey` (`g_thread_cache_key`) as the primary mechanism, but also leverages the `thread_local` C++ keyword (`g_thread_cache`) on supported platforms for a faster access path.
+-   **`ThreadCacheRegistry`:** This global singleton is the central authority for managing the lifecycle of all `ThreadCache` instances. It uses a lock (`ThreadCacheRegistry::GetLock()`) to protect its list of active caches, which is essential for preventing race conditions when threads are created and destroyed.
+-   **Tombstone on Thread Teardown:** The `ThreadCache::Delete` function, which is called when a thread terminates, sets the TLS slot to a special `kTombstone` value. This is a **critical security feature** that prevents the allocator from trying to re-create a cache for a thread that is already in the process of shutting down. This mitigates a class of use-after-free vulnerabilities that could occur if allocations happen late in the thread teardown process.
+
+## 2. Secure Cache Filling and Purging
+
+The logic for moving memory between the central partition and the thread cache is designed to be both efficient and safe.
+
+-   **Cache Filling (`FillBucket`):** When a thread needs memory, it fills its local cache bucket by acquiring the global partition lock *once* and then servicing multiple allocations.
+    -   **Security Implication:** This batching minimizes lock contention, which is important for preventing deadlocks and priority-inversion vulnerabilities in a complex multi-threaded application. The use of `AllocFlags::kFastPathOrReturnNull` is a key security detail, as it prevents the cache-fill operation from triggering more complex and long-running allocation paths (like allocating a new super-page) while holding the partition lock.
+
+-   **Cache Purging (`PurgeAll`):** The `ThreadCacheRegistry` orchestrates purging across all threads asynchronously by setting a `should_purge_` flag on each cache. The actual purge operation is then performed by each thread on its own cache during a subsequent allocation.
+    -   **Security Implication:** This asynchronous design avoids the need for one thread to directly manipulate the data structures of another, which would be a massive data race and a source of vulnerabilities. The security of the system relies on this strict separation.
+
+## 3. Post-`fork()` Handling
+
+-   **`ForcePurgeAllThreadAfterForkUnsafe` (line 179):** This function is a highly specialized and security-sensitive piece of code. It is designed to be called in a child process immediately after a `fork()`.
+-   **Security Implication:** It correctly acknowledges that after a `fork`, only one thread is running, and the state of all other threads' caches is unknown and potentially corrupt. The function attempts to reclaim the memory from these abandoned caches without crashing. The existence of this "unsafe" function highlights the inherent security dangers of using `fork()` in a complex multi-threaded program and represents a necessary, albeit risky, cleanup operation. Any use of this function outside of the immediate post-fork context would be a major security vulnerability.
+
+## Summary of Potential Security Concerns
+
+1.  **Re-entrancy:** The code uses a `PA_REENTRANCY_GUARD` in debug builds to prevent the allocator from being called again while it is already running on a given thread. In a release build, a re-entrant call (e.g., from a signal handler or a misbehaving system library callback) could corrupt the state of a thread's freelist, leading to an exploitable vulnerability.
+2.  **Global Lock Correctness:** The security of the `ThreadCacheRegistry` depends entirely on the correct and consistent use of its global lock. Any path that modifies the list of caches without acquiring the lock would introduce a race condition and a potential use-after-free.
+3.  **Tombstone Reliability:** The tombstone mechanism is the primary defense against UAFs during thread shutdown. If a platform's TLS implementation had a bug that prevented this value from being set correctly, it could lead to vulnerabilities.
+4.  **`fork()` Unsafely:** The post-fork handler is inherently risky. While necessary, it operates on potentially inconsistent data. A change in the `ThreadCache` layout could require a corresponding change in the fork handler to avoid a crash or memory corruption in the child process.

--- a/security_notes/components_safe_browsing_content_browser_safe_browsing_blocking_page.md
+++ b/security_notes/components_safe_browsing_content_browser_safe_browsing_blocking_page.md
@@ -1,0 +1,34 @@
+# Security Analysis of `safe_browsing_blocking_page.cc`
+
+This document provides a security analysis of the `SafeBrowsingBlockingPage` class. This class is a critical user-facing security component, responsible for rendering the interstitial warning page when a user attempts to navigate to a URL flagged as unsafe by Safe Browsing.
+
+## 1. Threat Details Reporting and Privacy
+
+The most significant security and privacy consideration for the blocking page is its ability to collect and send detailed reports about the threat back to Google.
+
+- **Data Collection:** The process is initiated in the constructor via the `TriggerManager`'s `StartCollectingThreatDetails` method. This can collect a wealth of information, including the URL, DOM structure, and other page resources, which is highly effective for discovering new threats.
+
+- **Primary Privacy Control: User Opt-In:**
+  - The entire mechanism is predicated on user consent. The data collection and reporting process is gated by `should_trigger_reporting` and the `DataCollectionPermissions` derived from the UI options. This typically corresponds to the "Automatically report details of possible security incidents to Google" checkbox on the interstitial.
+  - **Security Implication:** This is a **critical privacy control**. The security model relies on the `TriggerManager` and the UI layer to correctly interpret and enforce the user's opt-in decision. A bug in this logic that causes a report to be sent without user consent would be a major privacy violation. The `FinishThreatDetails` function (line 225) serves as the final gateway for sending the report, and its correct invocation is paramount.
+
+- **Fallback Reporting (`SendFallbackReport`, line 199):** In cases where the full, detailed report is not available but reporting is still desired, a more basic report is sent. This report contains less sensitive information (e.g., no DOM content) but still includes the malicious URL and user interaction data. This is a good robustness measure that ensures the Safe Browsing service continues to receive valuable data, even if the more complex collection process fails.
+
+## 2. User Action and Consequence
+
+The blocking page is a point of decision for the user, and the actions taken have further security consequences.
+
+- **Bypass as a Security Signal:** The user's decision to proceed through a warning (`proceeded()`) is treated as a security signal by other parts of the browser.
+- **`ignore_auto_revocation_notifications_trigger_` (line 171):** This is an excellent example of a defense-in-depth mechanism. If a user bypasses a social engineering (phishing) interstitial, this callback is triggered. This signal is used to prevent that origin from abusing the Notifications API in the future, based on the assumption that a site the user was warned about is more likely to be abusive. This links two separate security features (Safe Browsing and Abusive Notification prevention) to provide stronger overall protection.
+- **HaTS Surveys:** The `trust_safety_sentiment_service_trigger_` is used to initiate user surveys to gather feedback on the security warning. While not a direct security mechanism, it's an important tool for measuring and improving the effectiveness of security interventions.
+
+## 3. Metrics and Logging
+
+- **UKM Logging:** The page logs events to the URL-Keyed Metrics (UKM) service when an interstitial is shown and when it is bypassed (`LogSafeBrowsingInterstitialShownUKM`, `LogSafeBrowsingInterstitialBypassedUKM`).
+- **Security Implication:** This logging is essential for measuring the effectiveness of Safe Browsing warnings (e.g., calculating bypass rates for different threat types). The privacy of this data relies on the broader security and anonymization guarantees of the UKM framework.
+
+## Summary of Potential Security Concerns
+
+1.  **Privacy of Threat Details:** The single most critical security aspect of this component is ensuring that detailed threat reports, which can contain sensitive page content, are **never** sent without explicit user consent. The security hinges on the correct implementation and enforcement of the opt-in checkbox logic through the `TriggerManager` and `BaseSafeBrowsingErrorUI`.
+2.  **Complexity and Dependencies:** The `SafeBrowsingBlockingPage` is a complex class with many dependencies (`TriggerManager`, `HistoryService`, `SafeBrowsingMetricsCollector`, etc.). A vulnerability or logic bug in any of these dependent components could undermine the security or privacy guarantees of the blocking page.
+3.  **UI-Based Security:** The security of the page relies on presenting a clear and understandable warning to the user. Any bug in the UI logic that makes the "go back" option less prominent or the "proceed" option confusingly attractive could negatively impact user safety. The security of this component is directly tied to its effectiveness in user persuasion.

--- a/security_notes/components_safe_browsing_content_browser_threat_details.md
+++ b/security_notes/components_safe_browsing_content_browser_threat_details.md
@@ -1,0 +1,34 @@
+# Security Analysis of `threat_details.cc`
+
+This document provides a security analysis of the `ThreatDetails` class. This class is the core data collection engine for Safe Browsing reports. When a trigger fires, an instance of `ThreatDetails` is created to collect a rich set of information about the potentially malicious page, including its DOM structure, subresources, redirect chains, and cached content. This report is then sent to Google for analysis.
+
+## 1. Interaction with Untrusted Renderers (Security Boundary)
+
+The most significant security boundary crossed by this component is its interaction with the renderer process, which must be considered untrusted as it may be executing malicious code.
+
+- **`RequestThreatDOMDetails` (line 567):** This function sends a Mojo IPC request to the renderer process, asking it to serialize its DOM and send it back.
+- **DoS Protection:** The class imposes a hard limit of `kMaxDomNodes` (line 59) on the number of DOM nodes it will process from the renderer's response. This is a **critical security control** that prevents a malicious or compromised renderer from sending an enormous DOM tree, which could exhaust memory in the browser process and lead to a denial-of-service.
+- **Back-Forward Cache Disabling:** The implementation correctly disables the Back-Forward Cache for the frame from which it is collecting details (`DisableForRenderFrameHost`, line 568). This is an important security measure to prevent sensitive data from being stored in the cache and potentially exposed later.
+
+## 2. Data Sanitization and Privacy
+
+Because `ThreatDetails` collects potentially sensitive information, data sanitization is paramount to protecting user privacy.
+
+- **`ClearHttpsResource` (line 95):** This is the **most important privacy-preserving function** in this file. Before a report is sent, this function is called for every resource that was loaded over HTTPS. It meticulously scrubs the resource's request and response data, removing all HTTP headers **except for those on a predefined allowlist** (`g_https_headers_allowlist`).
+  - **Security Implication:** This explicitly prevents the leakage of highly sensitive information like `Cookie` and `Authorization` headers. The use of an allowlist is a robust design choice, as it is safer than a blocklist which might fail to include new, sensitive headers introduced in the future.
+- **URL Filtering (`IsReportableUrl`):** The code consistently checks if URLs are "reportable" before adding them to the report. This filters out internal schemes (e.g., `chrome://`) and other non-standard URLs, preventing the leakage of internal browser state.
+- **Report Trimming (`trim_to_ad_tags_`):** For reports triggered by malicious ads, there is an option to trim the collected DOM down to only the elements identified as being part of an ad. This is another privacy-enhancing feature that minimizes the collection of non-essential page content.
+
+## 3. Asynchronous Workflow and State Management
+
+The process of collecting all the necessary details is highly asynchronous, involving round-trips to the renderer, the history service, and the cache.
+
+- **Race Conditions:** The complex state management required for this asynchronous workflow is a potential source of bugs. The implementation relies on a sequence of callbacks (`OnReceivedThreatDOMDetails`, `OnRedirectionCollectionReady`, `OnCacheCollectionReady`) to assemble the final report. A logic error could lead to reports being sent prematurely with incomplete data, or worse, a use-after-free if an object is destroyed while a callback is still pending.
+- **Mitigation with `WeakPtr`:** The use of `GetWeakPtr()` (line 867) for posting callbacks is a critical mitigation against use-after-free vulnerabilities. If the `ThreatDetails` object is destroyed (e.g., because the tab is closed), the weak pointer will be invalidated, and the pending callbacks will be safely discarded.
+
+## Summary of Potential Security Concerns
+
+1.  **Vulnerabilities in Renderer-Side Code:** The security of the browser process relies on the renderer-side code that handles the `GetThreatDOMDetails` request being secure and robust. A vulnerability in that renderer code could be exploited by a malicious page to compromise the renderer.
+2.  **Data Sanitization Completeness:** The security of the `ClearHttpsResource` function depends on the allowlist of headers being correct and minimal. Any error that causes a sensitive header to be included on this list would result in a privacy leak.
+3.  **Information Leakage from History/Cache:** The collector queries the user's browsing history (for redirects) and cache. While this is necessary context, a bug in the collection logic could potentially leak more information than intended about the user's browsing habits.
+4.  **Complexity:** The sheer complexity of the asynchronous data collection process across multiple browser services makes it a high-risk area for subtle logic bugs and race conditions.

--- a/security_notes/components_safe_browsing_content_browser_triggers_trigger_manager.md
+++ b/security_notes/components_safe_browsing_content_browser_triggers_trigger_manager.md
@@ -1,0 +1,32 @@
+# Security Analysis of `trigger_manager.cc`
+
+This document provides a security analysis of the `TriggerManager` class. This class is a central component in the Safe Browsing threat details collection system. It acts as the primary gatekeeper, deciding whether to initiate the collection of potentially sensitive data from a user's web page in response to various security events (or "triggers").
+
+## 1. Primary Security Function: Enforcing User Consent and Privacy
+
+The most critical role of the `TriggerManager` is to enforce the user's privacy choices regarding the collection and reporting of security data. It does this through a multi-layered permission model.
+
+- **`CanStartDataCollectionWithReason` (line 143):** This is the main decision-making function that determines if a data collection process is allowed to even begin. It correctly enforces several fundamental privacy and security policies:
+  - **Incognito Mode:** It checks `is_off_the_record` and will **never** allow data collection to start in an Incognito window. This is a foundational privacy guarantee.
+  - **Enterprise Policies:** It checks `is_extended_reporting_opt_in_allowed`, ensuring that if an enterprise policy has disabled Extended Reporting, no collection will occur.
+  - **User Opt-In Requirement:** It calls `TriggerNeedsOptInForCollection` (line 27), which implements a nuanced and critical privacy distinction:
+    - For **foreground triggers** like a security interstitial (`SECURITY_INTERSTITIAL`), collection can begin *before* the user has opted in. This is because the user will be presented with an explicit opt-in choice on the interstitial page itself.
+    - For **background triggers** like an ad sample (`AD_SAMPLE`) or a suspicious site (`SUSPICIOUS_SITE`), collection is only allowed if the user has *already* opted into Extended Reporting. This is a vital distinction that prevents silent, non-consensual data collection.
+
+- **`CanSendReport` (line 63):** This function provides a second layer of defense. Even if data collection was started speculatively for an interstitial, this function is called before the report is actually sent. It performs a final check on the user's opt-in status (`is_extended_reporting_enabled`), ensuring that if the user did *not* check the opt-in box on the interstitial, the collected data is discarded and never sent. This two-step check (start collection, then confirm before sending) is a robust privacy-preserving design.
+
+## 2. Denial-of-Service Protection
+
+- **`TriggerThrottler`:** The `TriggerManager` uses a `TriggerThrottler` to enforce a daily quota on how many reports can be sent for each trigger type.
+- **Security Implication:** This is an essential mechanism for protecting the Safe Browsing backend infrastructure from being overwhelmed by a flood of reports. It prevents both misbehaving clients and potential amplification attacks from causing a denial-of-service against the reporting service. The `TriggerFired` method is called only after a report is successfully scheduled for sending, which correctly consumes a quota unit.
+
+## 3. State Management and Lifetime
+
+- **`data_collectors_map_`:** The manager maintains a map of active `ThreatDetails` collectors, keyed by the `WebContents` they are attached to.
+- **`WebContentsDestroyed` (line 322):** The manager correctly observes the destruction of WebContents and cleans up the corresponding data collector from its map. This is crucial for preventing memory leaks and use-after-free vulnerabilities that could arise if a tab is closed while a data collection is in progress.
+
+## Summary of Potential Security Concerns
+
+1.  **Complexity of Permission Logic:** The primary risk in this component is the complexity of the permission-checking logic. A bug in `CanStartDataCollectionWithReason` or `CanSendReport` could lead to a serious privacy incident where data is collected or sent against the user's wishes or in a context where it shouldn't be (e.g., Incognito). The security of the system relies on this logic being flawless.
+2.  **Correctness of `ThreatDetails`:** The `TriggerManager` initiates `ThreatDetails` collectors but does not perform the collection itself. Its security is therefore dependent on the `ThreatDetails` implementation correctly handling the data it collects and respecting the `should_send_report` flag passed to it.
+3.  **Policy and Preference Dependencies:** The manager's decisions are based on preferences and policies (`PrefService`). An incorrect configuration or a bug in how these preferences are read could lead to incorrect enforcement of the user's choices.

--- a/security_notes/components_site_isolation_site_isolation_policy.md
+++ b/security_notes/components_site_isolation_site_isolation_policy.md
@@ -1,0 +1,33 @@
+# Security Analysis of `site_isolation_policy.cc`
+
+This document provides a security analysis of the `SiteIsolationPolicy` class. This component is not the enforcement mechanism for Site Isolation itself (which resides deeper in `//content`), but rather the central policy engine that makes the high-level decision about **whether and when** to apply Site Isolation. Its decisions are based on a combination of hardware capabilities, enterprise policies, user settings, and runtime heuristics, making it a critical component for defining the browser's security posture.
+
+## 1. The Memory vs. Security Tradeoff
+
+The most significant security-relevant function of this class is its role in balancing security against performance, particularly on resource-constrained devices.
+
+- **`ShouldDisableSiteIsolationDueToMemoryThreshold` (line 228):** This function implements a critical, platform-specific policy. On Android, it checks the total amount of physical RAM on the device. If the memory is below a certain threshold (e.g., ~1.9GB for partial isolation, ~3.2GB for strict isolation), Site Isolation will be disabled.
+- **Security Implication:** This is a **deliberate and fundamental security tradeoff**. It means that users on lower-end devices receive a weaker security guarantee and are more exposed to cross-site data leaks and Spectre-style attacks. While this is a conscious product decision to maintain performance, it's the most significant security limitation controlled by this component. The security of users on these devices relies more heavily on other defenses (like the renderer sandbox and CORB/ORB).
+
+## 2. Heuristic-Based Isolation (Defense in Depth)
+
+When full Site Isolation is not enabled (e.g., on low-memory devices), the `SiteIsolationPolicy` is responsible for enabling a more targeted, heuristic-based approach to protect high-value websites.
+
+- **Password-Protected Sites (`IsIsolationForPasswordSitesEnabled`):** This function enables a policy to dynamically isolate a site *after* the user has entered a password on it. The origin is then persisted to user preferences (`PersistUserTriggeredIsolatedOrigin`, line 265) so that it will be isolated in future browsing sessions.
+- **OAuth Sites (`IsIsolationForOAuthSitesEnabled`):** A similar heuristic is applied to sites where the user logs in via OAuth, another high-value target for attackers.
+- **Security Implication:** This is a powerful defense-in-depth mechanism. It acknowledges that if not all sites can be protected, the most sensitive ones should be prioritized. However, it is inherently **reactive**; a site is only protected *after* the first time a user has trusted it with their credentials. The initial login event is not protected by process isolation.
+
+## 3. Policy Precedence and Configuration
+
+The policy enforcement logic demonstrates a robust and secure order of precedence, which is essential for preventing misconfigurations from leading to an insecure state.
+
+- **User Override:** The functions explicitly check for user-configured command-line or `chrome://flags` overrides first (e.g., line 141). This correctly gives the user the ultimate power to opt-in to a security feature, even if it might otherwise be disabled by memory thresholds.
+- **Global "Off" Switch:** The next check is `content::SiteIsolationPolicy::AreDynamicIsolatedOriginsEnabled()`, which respects global kill-switches like the `--disable-site-isolation-trials` flag or enterprise policies. This ensures that a global "off" command is always respected before any heuristic-based features are considered.
+- **Feature Flag:** Only after passing the user override and global policy checks does the code evaluate the `base::FeatureList::IsEnabled` status for a specific heuristic. This clear hierarchy prevents unexpected interactions between different control mechanisms.
+
+## Summary of Potential Security Concerns
+
+1.  **Deliberate Disabling of Security:** The primary security issue is the explicit, policy-driven disabling of Site Isolation on low-memory devices. This is a known and accepted risk, but it's a fundamental part of the security posture defined by this component.
+2.  **Complexity of Configuration:** The final security state is determined by a complex interaction of hardware checks, enterprise policies, multiple feature flags, and user settings. A bug in this logic or a misconfiguration during a field trial could lead to Site Isolation being unintentionally disabled.
+3.  **Reactive Nature of Heuristics:** The heuristic-based protections are reactive, meaning they only protect a site *after* a sensitive user action has already occurred. This leaves the initial interaction vulnerable.
+4.  **Persistence and Expiration Logic:** The policy persists isolated origins to user prefs. A bug in the logic that saves, loads (`ApplyPersistedIsolatedOrigins`), or expires these origins could cause a site to lose its protected status or, conversely, cause the list to grow indefinitely. The use of an expiration timeout for web-triggered origins is a good mitigation against the latter.

--- a/security_notes/content_browser_geolocation_geolocation_service_impl.md
+++ b/security_notes/content_browser_geolocation_geolocation_service_impl.md
@@ -1,0 +1,40 @@
+# Security Analysis of `geolocation_service_impl.cc`
+
+This document provides a security analysis of the `GeolocationServiceImpl` class. This class is the browser-side implementation of the Mojo interface that services requests for geolocation data from renderer processes. It acts as a critical security gatekeeper between a potentially untrusted web page and the user's physical location data.
+
+## 1. Enforcement of Permissions Policy
+
+The first and most important security check performed by the service is the enforcement of the Permissions Policy.
+
+- **`CreateGeolocation` (line 94):** Before any permission request is considered, this function immediately checks `render_frame_host_->IsFeatureEnabled(network::mojom::PermissionsPolicyFeature::kGeolocation)`.
+- **Security Implication:** This is a **critical security boundary**. It ensures that if a document has been disallowed from using geolocation by its embedder (e.g., an `<iframe>` with `allow="geolocation 'none'"`), the request is rejected instantly. This check correctly happens before any user-facing prompt is considered, enforcing the page's declared security policy as the highest priority. A failure to perform this check would allow embedded content to bypass the parent document's security constraints.
+
+## 2. Secure Permission Request Flow
+
+The service does not make permission decisions itself. Instead, it securely delegates this responsibility to the central `PermissionController`.
+
+- **`GeolocationServiceImplContext::RequestPermission` (line 32):** All requests for permission are funneled through `GetPermissionController()->RequestPermissionFromCurrentDocument(...)`.
+- **Security Implication:** This is a robust design that avoids reimplementing complex and security-critical UI and policy logic. It ensures that all Geolocation requests are subject to the same unified permission prompting behavior, `ContentSettings` persistence, and enterprise policies as every other permission in the browser. The service correctly passes the `user_gesture` flag, which is a crucial input for the `PermissionController` to decide whether a prompt can be shown.
+
+## 3. Robust Lifetime and State Management
+
+The class demonstrates strong practices for managing its lifetime and the state of the permission, which is crucial for preventing both use-after-free vulnerabilities and privacy leaks.
+
+- **Permission Revocation (`HandlePermissionResultChange`, line 154):**
+  - After a permission is granted, the service subscribes to any future changes for that permission.
+  - If the user later revokes the permission (e.g., through the site settings UI), this callback is triggered.
+  - It correctly calls `geolocation_context_->OnPermissionRevoked(...)`, which is a **vital privacy-preserving action**. This call ensures that the underlying device service is notified and immediately stops sending location updates to the renderer. Without this, a site could continue receiving location data even after the user believed they had revoked access.
+
+- **Preventing Request Spamming:** The `GeolocationServiceImplContext` uses a `has_pending_permission_request_` flag. If a renderer tries to make a new request while another is already in flight, the service calls `mojo::ReportBadMessage` (line 37). This terminates the renderer process, providing a strong defense against denial-of-service attacks or attempts to find race conditions by spamming permission prompts.
+
+- **Use of `WeakPtr`:** The implementation consistently uses a `WeakPtrFactory` for asynchronous callbacks that are bound to the lifetime of the `GeolocationServiceImpl`. This is a critical C++ security best practice that prevents use-after-free bugs if the `RenderFrameHost` is destroyed (e.g., the user navigates away) while a permission request is pending.
+
+## 4. Separation of Concerns
+
+The `GeolocationServiceImpl` does not handle the raw location data itself. After permission is granted, it binds the renderer's `device::mojom::Geolocation` receiver directly to the `GeolocationContext` in the device service. This is a clean architectural separation that limits the attack surface of this class; its sole responsibility is permission brokering, not data handling.
+
+## Summary of Potential Security Concerns
+
+1.  **Dependency on `PermissionController`:** The security of the entire flow is critically dependent on the correctness of the `PermissionController` and its delegate. Any vulnerability in the central permission system would be directly exploitable through this service.
+2.  **Correctness of Frame Identification:** The service relies on the provided `RenderFrameHost` to correctly identify the requesting origin and its associated Permissions Policy. A bug in a higher-level component that provided the wrong `RenderFrameHost` could lead to a policy bypass.
+3.  **Mojo Security:** The service relies on the security guarantees of the underlying Mojo IPC system to ensure that a compromised renderer cannot spoof its frame's identity or otherwise tamper with the messages sent to the browser process.

--- a/security_notes/content_browser_permissions_permission_controller_impl.md
+++ b/security_notes/content_browser_permissions_permission_controller_impl.md
@@ -1,0 +1,35 @@
+# Security Analysis of `permission_controller_impl.cc`
+
+This document provides a security analysis of the `PermissionControllerImpl` class. This class is the central hub for permission management within the browser process. It acts as the authority that orchestrates permission checks and requests, applying security policies and delegating decisions to the embedder (e.g., Chrome). Its correctness is fundamental to the entire web permissions security model.
+
+## 1. Role as a Central Dispatcher and Delegate
+
+The `PermissionControllerImpl` does not, by itself, make the final decision to grant or deny a permission. Instead, its primary role is to act as a secure dispatcher.
+
+- **Delegation to `PermissionControllerDelegate`:** The controller forwards all key decisions—such as whether to prompt the user (`RequestPermissionsFromCurrentDocument`), what the current permission status is (`GetPermissionResultFor...`), and how to reset a permission—to the `PermissionControllerDelegate`.
+- **Security Implication:** This is a strong architectural pattern. It separates the core orchestration logic within `//content` from the embedder-specific policy and UI logic (e.g., in `//chrome`). The security of the permission system, therefore, hinges on the **correct and secure implementation of the `PermissionControllerDelegate`**. A bug in the delegate (e.g., incorrectly interpreting a request, showing a confusing prompt, or having flawed logic for `ContentSettings`) would undermine the security enforced by the controller.
+
+## 2. Enforcement of Security Context and Policies
+
+The controller is the first line of defense for enforcing critical, low-level security policies before a request is even delegated.
+
+- **Fenced Frames (`IsNestedWithinFencedFrame`):** In `VerifyContextOfCurrentDocument` (line 115), the controller explicitly checks if the requesting frame is a fenced frame. If so, the permission is immediately denied. This is a **critical security boundary enforcement**, as fenced frames are designed to be highly isolated and must not have access to powerful device permissions.
+
+- **Permissions Policy (`PermissionAllowedByPermissionsPolicy`):** The controller checks if the permission is allowed by the document's Permissions Policy. This allows developers to declaratively disable features in iframes, which is a key mechanism for securing embedded content. Failing to enforce this would allow a subframe to bypass the top-level document's intended security policy.
+
+- **Back-Forward Cache (`IsInactiveAndDisallowActivation`):** Before processing a request, the controller ensures the requesting frame is active and evicts it from the Back-Forward Cache if necessary. This is a crucial security measure to prevent a page from being restored from the cache with a stale or incorrect permission state.
+
+## 3. Secure Handling of DevTools Overrides
+
+The controller provides a mechanism for developers to override permission states via DevTools.
+
+- **`permission_overrides_`:** This member stores the overrides set by DevTools. The `GetPermission...` and `RequestPermissions...` methods all check for an override first before proceeding with the normal flow.
+- **Security Model:** The security of this feature relies on the principle that DevTools is a trusted, user-initiated part of the browser. There are no IPCs from the renderer that can directly manipulate these overrides. The implementation correctly isolates this override logic from the standard permission flow, applying it as a final decision layer. The risk is minimal, assuming DevTools itself is not compromised.
+- **Cookie Manager Updates:** A notable detail is that when a storage access permission is overridden, the controller correctly calls `UpdateCookieManagerContentSettings` (line 595) to propagate this setting to the network service. This ensures that the browser's networking stack respects the developer-overridden state, which is important for testing and debugging.
+
+## Summary of Potential Security Concerns
+
+1.  **Dependency on the Delegate:** The most significant security consideration is the controller's complete reliance on the `PermissionControllerDelegate`. Any vulnerability, logic flaw, or policy misconfiguration in the delegate's implementation will be directly reflected in the final permission decision.
+2.  **Context Confusion:** The controller handles requests from various contexts (main frames, iframes, workers). A bug in how it determines the `requesting_origin` versus the `embedding_origin` could lead to a permission bypass, where a frame is granted a permission based on the wrong context (e.g., an iframe inheriting a permission intended only for the top-level site). The clear separation of functions like `GetPermissionResultForCurrentDocument` and `GetPermissionResultForWorker` is designed to mitigate this risk.
+3.  **Complexity of Overrides:** While the DevTools override mechanism appears secure, its interaction with other systems (like the cookie manager and subscription notifications) adds complexity. A bug in how overrides are applied or reset could lead to an inconsistent permission state across the browser.
+4.  **"God Mode" of the Controller:** As the central permission authority, any compromise or logic bug within `PermissionControllerImpl` itself would be catastrophic, as it could potentially grant any permission to any origin without user consent. Its role as a secure dispatcher, relying on a delegate for the actual decisions, is a key design choice that limits its internal complexity and attack surface.

--- a/security_notes/content_browser_permissions_permission_service_impl.md
+++ b/security_notes/content_browser_permissions_permission_service_impl.md
@@ -1,0 +1,32 @@
+# Security Analysis of `permission_service_impl.cc`
+
+This document provides a security analysis of the `PermissionServiceImpl` class. This class lives in the browser process and is the direct recipient of permission-related Mojo IPCs from renderer processes. It serves as the primary security boundary for validating and dispatching permission queries (`HasPermission`), requests (`RequestPermissions`), and revocations (`RevokePermission`) initiated by websites.
+
+## 1. Role as a Security Boundary (IPC Validation)
+
+The most critical security function of `PermissionServiceImpl` is to act as a gatekeeper, validating all incoming requests from untrusted renderer processes before they reach more privileged components like the `PermissionController`.
+
+- **Malformed Descriptor Handling:** The service consistently uses helpers like `MaybePermissionDescriptorToPermissionType` to convert the Mojo permission descriptor from the renderer into a strongly-typed C++ enum (`blink::PermissionType`). If this conversion fails, it means the renderer has sent an invalid or unknown permission type.
+- **`ReceivedBadMessage`:** In all cases where validation fails (e.g., invalid permission type, duplicate permissions in a single request), the service correctly calls `ReceivedBadMessage` (line 540). This is a **vital security mechanism** that terminates the offending renderer process. This harsh but necessary action prevents a compromised or malicious renderer from repeatedly sending malformed data in an attempt to probe for parsing bugs or logic flaws in the browser process.
+- **Duplicate Permission Prevention:** The `HasDuplicatesOrInvalidPermissions` helper (line 84) explicitly checks for duplicate permission types within a single `RequestPermissions` call. This prevents ambiguity and potential logic errors in downstream code that processes the request.
+
+## 2. Enforcement of Context and Origin
+
+The service correctly enforces the security context of the permission request, ensuring that a frame can only request permissions for its own origin.
+
+- **Origin Scoping:** The `PermissionServiceImpl` is instantiated with a specific `origin_` (line 153), and all its operations are implicitly scoped to that origin. This prevents a compromised renderer from trying to query or request permissions for a different origin.
+- **Frame vs. Worker Context:** The implementation correctly handles requests that may not have an associated `RenderFrameHost` (e.g., those from a dedicated worker). In `RequestPermissions` (line 274), if there is no frame host, it correctly avoids trying to show a permission prompt (which is impossible) and instead returns the current status of the permission. This prevents crashes and ensures the API behaves in a safe, predictable manner.
+- **Domain Override Validation:** For permissions that support a domain override (a niche feature), `PermissionUtil::ValidateDomainOverride` is called (line 307) to ensure the requesting frame is actually allowed to request a permission on behalf of another origin. This prevents abuse of this feature.
+
+## 3. Page-Embedded Permission Controls (`<permission>`)
+
+The service contains the entry point for the experimental `<permission>` element feature.
+
+- **Feature Flag Gating:** All logic related to this feature is correctly gated by the `blink::features::kPermissionElement` feature flag. This is a standard and essential practice for ensuring that experimental and potentially unstable features are not exposed to users by default.
+- **Delegation of Security Checks:** The `PermissionServiceImpl` does not implement the complex security logic for this feature itself. Instead, it delegates the decision to the `EmbeddedPermissionControlChecker` (line 173). This is a good design that separates the IPC-handling logic from the feature-specific security policy logic. The security of the `<permission>` element relies on the correctness of the `EmbeddedPermissionControlChecker`.
+
+## Summary of Potential Security Concerns
+
+1.  **Completeness of Validation:** The security of this boundary rests on the assumption that its validation is complete. If a new permission type with unique security properties were added to Blink, the validation logic in `PermissionServiceImpl` (e.g., `HasDuplicatesOrInvalidPermissions`, checks for device permissions) would need to be updated accordingly. An omission could allow a malformed request to bypass this layer.
+2.  **Vulnerabilities in `PermissionControllerImpl`:** The `PermissionServiceImpl` is primarily a dispatcher. It forwards validated requests to the `PermissionControllerImpl`. Therefore, any logic vulnerability, state confusion bug, or policy bypass in the `PermissionControllerImpl` would be directly reachable through this service. The overall security of the permissions system depends on the `PermissionControllerImpl` being secure.
+3.  **Security of the `<permission>` Element Feature:** As an experimental feature, the logic for handling page-embedded permissions is inherently higher risk. A bug in the `EmbeddedPermissionControlChecker` could allow a malicious site to abuse the `<permission>` element to trick the user or gain permissions in an unexpected way.

--- a/security_notes/mojo_core.md
+++ b/security_notes/mojo_core.md
@@ -1,0 +1,66 @@
+# Security Analysis of Mojo Core: The Core API
+
+**File:** `mojo/core/core.cc`
+
+## 1. Overview
+
+The `Core` class, implemented in `mojo/core/core.cc`, is the heart of the Mojo system within a single process. It acts as the central nexus for all Mojo functionality, serving as the concrete implementation behind the public Mojo C API (e.g., `MojoCreateMessagePipe`, `MojoWriteMessage`, etc.). It is effectively a singleton that manages the process-global state required for Mojo to operate.
+
+From a security perspective, `Core` is the ultimate gatekeeper. Every interaction with Mojo from the user's code, whether malicious or benign, must pass through this class. Its primary responsibilities are managing object lifetimes, enforcing security policies, and translating abstract API calls into concrete actions on the underlying IPC primitives.
+
+## 2. Core Components & Responsibilities
+
+The `Core` class owns and manages several critical components:
+
+*   **`HandleTable`**: This is arguably the most important security component in the file. It maintains the mapping between the opaque `MojoHandle` (a `uint32_t`) that is exposed to the API user and the internal, strongly-typed `Dispatcher` objects that implement the handle's functionality. All access to the `HandleTable` is guarded by a lock to prevent race conditions.
+    *   **Security Implication**: The integrity of the `HandleTable` is paramount. A bug here could lead to use-after-free, type confusion (e.g., treating a `DataPipeDispatcher` as a `MessagePipeDispatcher`), or handle leaks. The atomic `GetAndRemoveDispatcher` operation is crucial for safely closing handles and performing consuming operations like `FuseMessagePipes`.
+
+*   **`NodeController`**: `Core` owns the `NodeController`, which in turn manages the `ports::Node` for the process. The `NodeController` is responsible for all cross-node (and therefore cross-process) communication logic, including peer discovery and channel management. `Core` acts as the interface between the API and the `NodeController`.
+
+*   **`MappingTable`**: This table tracks all active shared memory mappings created via `MojoMapBuffer`. It maps the memory address returned to the user to the underlying `PlatformSharedMemoryMapping` object. This is also protected by a lock.
+    *   **Security Implication**: This prevents a user from, for example, unmapping an arbitrary pointer. When `MojoUnmapBuffer` is called, the address is looked up in this table. If it's not present, the call is rejected. This prevents wild unmaps. The table also has a size limit (`max_mapping_table_size`) to mitigate denial-of-service attacks via excessive mapping requests.
+
+## 3. Security-Critical Operations
+
+### Handle Lifecycle Management
+
+The `Core` class meticulously manages the lifecycle of every Mojo object through its `HandleTable`.
+
+*   **Creation**: Functions like `MojoCreateMessagePipe` or `MojoCreateDataPipe` result in the creation of one or more `Dispatcher` objects, which are then added to the `HandleTable` via `AddDispatcher`, returning a new `MojoHandle` to the user.
+*   **Usage**: Any API call that takes a `MojoHandle` (e.g., `MojoWriteMessage`) first calls `GetDispatcher` to safely look up the corresponding `Dispatcher` object. If the handle is invalid, `GetDispatcher` returns `nullptr`, and the operation fails.
+*   **Destruction**: `MojoClose` uses `GetAndRemoveDispatcher` to atomically retrieve and remove the `Dispatcher` from the table, after which the `Dispatcher`'s `Close()` method is called. This two-step process ensures that no other thread can access the handle after it has been marked for closure.
+
+### Invitation and IPC Bootstrapping
+
+The invitation system is the mechanism for establishing a new IPC connection between two processes. This is an extremely security-sensitive process.
+
+*   **`SendInvitation`**: This function is a major security boundary. It takes a local `InvitationDispatcher`, a target process handle, and a platform-specific transport endpoint.
+    *   **Validation**: It performs rigorous validation on its arguments. It ensures the transport endpoint is valid and unwraps the process handle.
+    *   **Policy Flags**: It respects security-relevant options like `MOJO_SEND_INVITATION_FLAG_UNTRUSTED_PROCESS` and `MOJO_SEND_INVITATION_FLAG_ISOLATED`. These flags are passed down to the `NodeController` to inform its policy decisions (e.g., whether to treat the connection as hostile).
+    *   **Error Handling**: It allows the caller to register an error handler that will be notified if the remote process disconnects or crashes. This is critical for robustly managing the lifecycle of cross-process connections.
+
+*   **`AcceptInvitation`**: This is the corresponding operation in the remote process. It takes a platform handle (the other end of the channel) and registers it with the `NodeController` to establish the connection.
+
+### Message Handling and Validation
+
+While most message logic resides in `Channel` and `UserMessageImpl`, `Core` provides the top-level API and adds a final layer of validation.
+
+*   **`NotifyBadMessage`**: This API is a critical part of the security model. It allows a process to report that it has received a malformed or unexpected message from a peer. The `Core` routes this notification to the `NodeController`, which can then use its internal knowledge of the peer's identity (`source_node`) to take action, such as terminating the offending process. This provides a formal mechanism for punishing misbehaving IPC partners rather than simply crashing.
+
+## 4. Potential Vulnerabilities & Mitigations
+
+*   **Race Conditions**:
+    *   **Threat**: Multiple threads manipulating the same handle could lead to use-after-free or other corruption.
+    *   **Mitigation**: The `HandleTable` and `MappingTable` are both protected by locks. All operations on these tables are performed while holding the appropriate lock, providing strong protection against race conditions.
+
+*   **Resource Exhaustion (Denial of Service)**:
+    *   **Threat**: A malicious actor could attempt to create an unlimited number of handles or memory mappings, exhausting process resources.
+    *   **Mitigation**: The `HandleTable` has an implicit limit based on available memory. The `MappingTable` has an explicit, configurable size limit (`max_mapping_table_size`). Functions that deserialize messages also have internal limits, such as `kMaxHandlesPerMessage`, to prevent absurdly large allocation requests.
+
+*   **Logic Bugs in Invitation Flow**:
+    *   **Threat**: The process of creating, sending, and accepting invitations is complex. A logic flaw could allow a process to connect to an unintended peer or bypass security policies.
+    *   **Mitigation**: The logic is well-encapsulated. The `InvitationDispatcher` holds the state for a pending invitation, and the `Core` API ensures that handles are correctly created and consumed. The use of flags like `ISOLATED` and `UNTRUSTED_PROCESS` provides clear security annotations for the `NodeController` to act upon.
+
+## 5. Conclusion
+
+The `Core` class is the central nervous system of Mojo IPC. Its design demonstrates a robust security posture built on several key principles: centralized ownership of critical resources (`HandleTable`, `NodeController`), strong typing through the `Dispatcher` pattern, meticulous locking to prevent race conditions, and explicit mechanisms for resource limiting and error handling (`NotifyBadMessage`). While the low-level `Channel` is responsible for safely parsing bytes, `Core` is responsible for safely managing object lifecycles and enforcing the high-level security policy of the entire Mojo system. The invitation workflow remains the most complex and, therefore, highest-risk area for potential logic vulnerabilities.

--- a/security_notes/mojo_data_pipe_consumer_dispatcher.md
+++ b/security_notes/mojo_data_pipe_consumer_dispatcher.md
@@ -1,0 +1,75 @@
+# Security Analysis of Mojo Core: DataPipeConsumerDispatcher
+
+**File:** `mojo/core/data_pipe_consumer_dispatcher.cc`
+
+## 1. Overview
+
+The `DataPipeConsumerDispatcher` is the "read" endpoint of a Mojo data pipe and the direct counterpart to the `DataPipeProducerDispatcher`. Its responsibility is to provide a safe interface for reading data out of the shared circular buffer and to provide the critical feedback to the producer about how much data has been consumed.
+
+The security of this component is paramount, as it is the final gatekeeper that prevents a malicious producer from tricking a process into reading invalid memory. Its design must be robust against corrupted or malicious control messages and must correctly manage its view of the shared buffer's state.
+
+## 2. Core Components & State Management
+
+The consumer's state management is a mirror image of the producer's, built around the same principles of a locked state machine and an out-of-band control channel.
+
+*   **`shared_ring_buffer_` / `ring_buffer_mapping_`**: The `base::UnsafeSharedMemoryRegion` and its corresponding memory mapping, providing direct read access to the data.
+*   **`control_port_` (`ports::PortRef`)**: The message pipe used to receive `DATA_WAS_WRITTEN` notifications from the producer and, crucially, to send `DATA_WAS_READ` acknowledgements back.
+*   **State Variables (all protected by `lock_`)**:
+    *   `read_offset_`: The byte offset into the circular buffer from which the next read will start.
+    *   `bytes_available_`: The number of bytes the consumer believes are available to be read.
+    *   `in_two_phase_read_`: A flag to prevent nested or interleaved two-phase reads.
+    *   `new_data_available_`: A flag used to correctly manage the `MOJO_HANDLE_SIGNAL_NEW_DATA_READABLE` signal, which only fires once per new batch of data.
+    *   Standard lifecycle flags: `is_closed_`, `peer_closed_`, `in_transit_`, `transferred_`.
+
+## 3. Security-Critical Operations
+
+### State Synchronization (`UpdateSignalsStateNoLock`)
+
+This function is the core of the consumer's security model. It processes incoming control messages from the producer to update its local state.
+
+**Mechanism:**
+
+1.  The producer, after writing N bytes, sends a `DATA_WAS_WRITTEN` control message with the value N to the consumer's `control_port_`.
+2.  The consumer's `PortObserverThunk` detects the message and triggers `OnPortStatusChanged`, which calls `UpdateSignalsStateNoLock`.
+3.  `UpdateSignalsStateNoLock` reads all pending `DATA_WAS_WRITTEN` messages. For each message, it performs a critical validation:
+    *   **`base::CheckAdd(bytes_available_, m->num_bytes)`**: It uses a checked addition to increase its `bytes_available_` counter.
+    *   **Capacity Check**: It validates that the new `bytes_available_` does not exceed the total `options_.capacity_num_bytes`. This is the single most important check: it prevents a malicious producer who claims to have written more data than fits in the buffer from tricking the consumer into reading out of bounds. If this check fails, the peer is immediately marked as closed, and the pipe is shut down.
+
+By validating against its own trusted knowledge of the buffer's capacity, the consumer never has to trust the producer's state.
+
+### Reading Data
+
+The consumer provides a rich API for reading data, including one-shot, two-phase, query, and discard operations.
+
+*   **One-shot (`ReadData`)**:
+    *   **Flag Validation**: It first validates the user-provided option flags, ensuring that mutually exclusive flags like `PEEK` and `DISCARD` are not used together.
+    *   **Capacity Checks**: It determines how many bytes to read based on the user's request and the locally-tracked `bytes_available_`.
+    *   **Safe `memcpy`**: It reads from the circular buffer, correctly handling the potential wrap-around.
+    *   **Feedback Loop**: If the operation was not a `PEEK`, it updates its `read_offset_` and `bytes_available_` and then calls **`NotifyRead()`**. This function sends the `DATA_WAS_READ` control message back to the producer, completing the synchronization loop and allowing the producer to make more space available.
+
+*   **Two-phase (`BeginReadData` / `EndReadData`)**:
+    *   **Serialization**: The `in_two_phase_read_` flag prevents other read operations from interfering.
+    *   **Pointer Safety**: `BeginReadData` returns a pointer directly into the shared buffer. Critically, it only exposes a contiguous block of memory (up to the end of the buffer) and records the size of this block in `two_phase_max_bytes_read_`.
+    *   **Validation**: `EndReadData` validates that the number of bytes the user claims to have read does not exceed `two_phase_max_bytes_read_`. This prevents the user from claiming to have read past the end of the contiguous block that was exposed.
+
+### Deserialization (`Deserialize`)
+
+This function is symmetric to the producer's `Deserialize` and performs the same rigorous checks. It validates the number of handles, the size of the state payload, and the consistency of the state's internal values (e.g., `bytes_available` <= `capacity_num_bytes`) before creating a new dispatcher.
+
+## 4. Potential Vulnerabilities & Mitigations
+
+*   **Buffer Over-read from Malicious Producer**:
+    *   **Threat**: A malicious producer sends a corrupt `DATA_WAS_WRITTEN` message to trick the consumer into making more bytes "available" than the buffer holds, leading to an out-of-bounds read.
+    *   **Mitigation**: The strict capacity check in `UpdateSignalsStateNoLock` catches this and shuts down the pipe.
+
+*   **Application-Level Race Conditions**:
+    *   **Threat**: An application uses multiple threads to perform a two-phase read on the same handle.
+    *   **Mitigation**: The `in_two_phase_read_` flag, protected by the dispatcher's lock, serializes these operations.
+
+*   **Information Leak via `QUERY`**:
+    *   **Threat**: A bug could cause the `QUERY` operation to modify state or leak more information than intended.
+    *   **Mitigation**: The implementation of `MOJO_READ_DATA_FLAG_QUERY` is carefully isolated. It reads `bytes_available_` and returns immediately, with no other state modification.
+
+## 5. Conclusion
+
+The `DataPipeConsumerDispatcher` securely completes the data pipe abstraction. It is a robust and well-designed component that provides a safe interface over shared memory. Its security model, based on validated, out-of-band control messages, effectively isolates it from having to trust any state managed by its (potentially malicious) peer. The careful validation during deserialization, state updates, and two-phase reads demonstrates a thorough, defense-in-depth approach to preventing common shared memory vulnerabilities. The entire data pipe system, comprising both the producer and consumer dispatchers, represents a strong example of how to build a secure, high-performance IPC primitive.

--- a/security_notes/mojo_data_pipe_producer_dispatcher.md
+++ b/security_notes/mojo_data_pipe_producer_dispatcher.md
@@ -1,0 +1,88 @@
+# Security Analysis of Mojo Core: DataPipeProducerDispatcher
+
+**File:** `mojo/core/data_pipe_producer_dispatcher.cc`
+
+## 1. Overview
+
+The `DataPipeProducerDispatcher` implements the "write" endpoint of a Mojo data pipe. Its primary role is to provide a safe and efficient interface for writing data into a shared circular buffer that will be read by a corresponding `DataPipeConsumerDispatcher`. This component is critical for performance-sensitive bulk data transfer, but it operates on shared memory, a primitive rife with potential security hazards.
+
+The security of the data pipe hinges on the producer's ability to correctly manage its view of the shared buffer's state (e.g., how much space is available) and to synchronize that state safely with its peer, the consumer. Any flaw could lead to data corruption, race conditions, or information leaks.
+
+## 2. Core Components & State Management
+
+The dispatcher's design centers on a lock-protected state machine that synchronizes with the consumer via an out-of-band control channel.
+
+*   **`shared_ring_buffer_`**: An `base::UnsafeSharedMemoryRegion` that represents the data buffer. The "Unsafe" designation is key: it implies that both endpoints map the memory as writable and that there is no OS-level enforcement of read-only access.
+*   **`ring_buffer_mapping_`**: The producer's actual memory mapping of the shared buffer, providing the raw pointer for `memcpy`.
+*   **`control_port_` (`ports::PortRef`)**: This is the cornerstone of the synchronization mechanism. It's a separate, standard message pipe used exclusively for sending control messages between the producer and consumer. The producer sends `DATA_WAS_WRITTEN` notifications to the consumer, and the consumer sends `DATA_WAS_READ` notifications back.
+*   **State Variables (all protected by `lock_`)**:
+    *   `write_offset_`: The current byte offset into the circular buffer where the next write should begin.
+    *   `available_capacity_`: The number of bytes the producer believes are free for writing. This is the producer's local source of truth.
+    *   `in_two_phase_write_`: A boolean flag that prevents nested or interleaved writes when using the `BeginWriteData`/`EndWriteData` API.
+    *   `peer_closed_`: A flag indicating that the consumer is gone. Once set, all writes will fail.
+    *   Standard lifecycle flags: `is_closed_`, `in_transit_`, `transferred_`.
+
+## 3. Security-Critical Operations
+
+### State Synchronization (`UpdateSignalsStateNoLock`)
+
+This is the most critical security function in the dispatcher. It is responsible for processing feedback from the consumer and updating the producer's view of the buffer's state.
+
+**Mechanism:**
+
+1.  The consumer, after reading N bytes, sends a `DATA_WAS_READ` control message containing the value N back to the producer via the `control_port_`.
+2.  The producer's `PortObserverThunk` is notified of message arrival on the `control_port_`, triggering `OnPortStatusChanged`.
+3.  `OnPortStatusChanged` calls `UpdateSignalsStateNoLock`.
+4.  `UpdateSignalsStateNoLock` reads all pending control messages. For each `DATA_WAS_READ` message, it performs a critical validation:
+    *   **`base::CheckAdd(available_capacity_, m->num_bytes)`**: It uses a checked addition to increase its `available_capacity_`. If a malicious consumer claims to have read an impossibly large number of bytes (e.g., one that would cause `available_capacity_` to wrap around or exceed the total buffer size), the check will fail.
+5.  If validation fails, the message is considered corrupt, and the peer is treated as closed, preventing any further state corruption.
+
+This explicit, validated message-passing protocol for synchronization is far safer than relying on shared memory flags or other implicit mechanisms. The producer never trusts the consumer's state; it only trusts validated messages from the consumer to update its own state.
+
+### Writing Data
+
+The dispatcher supports two modes of writing: one-shot and two-phase.
+
+*   **One-shot (`WriteData`)**:
+    *   It checks for available capacity and fails with `MOJO_RESULT_SHOULD_WAIT` if the buffer is full.
+    *   It carefully calculates how to `memcpy` the user's data into the circular buffer, potentially splitting the write into two parts if it needs to wrap around the end of the buffer.
+    *   After the copy, it decrements `available_capacity_` and sends a `DATA_WAS_WRITTEN` control message to the consumer via `NotifyWrite`.
+
+*   **Two-phase (`BeginWriteData` / `EndWriteData`)**:
+    *   `BeginWriteData` sets the `in_two_phase_write_` flag to `true`, which locks the dispatcher from any other write operations, returning `MOJO_RESULT_BUSY` if another write is attempted. This prevents race conditions. It returns a direct pointer into the shared buffer.
+    *   `EndWriteData` validates that the user-written byte count is valid, updates the state, clears the `in_two_phase_write_` flag, and notifies the consumer.
+
+### Deserialization (`Deserialize`)
+
+This function reconstructs a producer dispatcher when a handle is received over IPC.
+
+**Key Security Checks:**
+
+*   It expects exactly one platform handle (for the shared memory) and one port (for the control channel).
+*   It validates all fields in the `SerializedState` struct. The `write_offset` and `available_capacity` must be consistent with the total buffer capacity.
+*   It safely creates the `UnsafeSharedMemoryRegion` from the platform handle and maps it.
+
+Any failure in this chain results in `nullptr` being returned, preventing a partially-initialized or corrupted dispatcher from being created.
+
+## 4. Potential Vulnerabilities & Mitigations
+
+*   **Data Corruption from Malicious Consumer**:
+    *   **Threat**: A malicious consumer sends a bogus `DATA_WAS_READ` message, trying to trick the producer into believing space has been freed when it hasn't.
+    *   **Mitigation**: The `CheckAdd` validation in `UpdateSignalsStateNoLock` detects this. The producer will see that the consumer is trying to free more space than exists, will consider the peer closed, and will stop writing.
+
+*   **Race Conditions from Application Code**:
+    *   **Threat**: Multiple threads in the same process try to perform a two-phase write simultaneously on the same handle.
+    *   **Mitigation**: The `in_two_phase_write_` flag, protected by the dispatcher's lock, serializes these operations, returning `MOJO_RESULT_BUSY` to the second caller.
+
+*   **TOCTOU in Two-Phase Writes**:
+    *   **Threat**: The user calls `BeginWriteData`, gets a buffer, but then the peer closes the pipe before the user calls `EndWriteData`.
+    *   **Mitigation**: The API allows `EndWriteData` to succeed even if the peer has closed. The data is written to the buffer, but it will never be read. This is considered safe and predictable behavior.
+
+## 5. Conclusion
+
+The `DataPipeProducerDispatcher` is a well-secured component that provides a safe interface over the hazardous primitive of shared memory. Its security model is built on three pillars:
+1.  **Strongly-typed, lock-protected state**: All internal state is guarded by a lock, preventing races.
+2.  **Out-of-band, validated synchronization**: Instead of trusting state in shared memory, it uses a separate message pipe for control messages and rigorously validates the content of those messages.
+3.  **Strict lifecycle and transactional state**: The `in_two_phase_write_` and `in_transit_` flags ensure that the dispatcher is always in a well-defined state and cannot be misused during sensitive operations.
+
+This design effectively mitigates the common pitfalls of shared memory IPC, such as synchronization errors and race conditions.

--- a/security_notes/mojo_message_pipe_dispatcher.md
+++ b/security_notes/mojo_message_pipe_dispatcher.md
@@ -1,0 +1,74 @@
+# Security Analysis of Mojo Core: MessagePipeDispatcher
+
+**File:** `mojo/core/message_pipe_dispatcher.cc`
+
+## 1. Overview
+
+The `MessagePipeDispatcher` is the `Dispatcher` implementation for the most fundamental Mojo primitive: the message pipe. It provides the backing logic for `MojoHandle`s that represent one of the two endpoints of a message pipe. This dispatcher is the crucial link between the user-facing Mojo C API (e.g., `MojoWriteMessage`, `MojoReadMessage`, `MojoFuseMessagePipes`) and the underlying `ports` library, which handles the abstract routing and queuing of messages.
+
+From a security perspective, the `MessagePipeDispatcher` is a high-traffic component that must correctly manage its lifecycle, enforce resource limits, and faithfully represent the state of the underlying `ports::Port` to the user.
+
+## 2. Core Components & State Management
+
+The dispatcher's state is designed to be thread-safe and robustly manage the lifecycle of a message pipe endpoint.
+
+*   **`port_` (`ports::PortRef`)**: This is the dispatcher's handle to the underlying port in the `ports` library. All message operations are ultimately delegated to this port.
+*   **`signal_lock_`**: A `base::Lock` that protects all mutable state within the dispatcher. This is the primary defense against race conditions when multiple threads interact with the same handle.
+*   **Lifecycle Flags (`port_closed_`, `in_transit_`, `port_transferred_`)**: These atomic flags track the dispatcher's state.
+    *   `port_closed_`: True if `MojoClose` has been called.
+    *   `in_transit_`: True if the handle is currently being serialized for transit to another process. This acts as a transactional lock, preventing any other operations on the handle.
+    *   `port_transferred_`: True if the handle has been successfully sent to another process.
+*   **`watchers_` (`WatcherSet`)**: Manages the set of `MojoTrap` event handlers (watchers) that are armed to watch for signal changes on this handle.
+*   **Quota Limits**: The dispatcher stores optional limits (`receive_queue_length_limit_`, `receive_queue_memory_size_limit_`, `unread_message_count_limit_`) to enforce backpressure and prevent denial-of-service attacks.
+
+## 3. Security-Critical Operations
+
+### Lifecycle and Transit Management
+
+The correct management of the dispatcher's lifecycle, especially when it's being sent to another process, is critical for preventing use-after-free and race conditions.
+
+*   **`Close()`**: Atomically sets the `port_closed_` flag and notifies all watchers that the handle is closed. It then calls `node_controller_->ClosePort` to tear down the underlying `ports` object, unless the port has already been transferred.
+*   **`BeginTransit()`**: This is called when the handle is attached to a message. It acquires the `signal_lock_` and sets `in_transit_` to `true`, preventing any other operations (read, write, close, watch) from succeeding while the handle is in this intermediate state.
+*   **`CompleteTransitAndClose()`**: Called after the handle is successfully serialized. It marks the port as transferred and calls `CloseNoLock()` to clean up the local dispatcher object. The underlying port itself is *not* closed, as its ownership has been passed to the remote process.
+*   **`CancelTransit()`**: If serialization fails, this is called to release the `in_transit_` lock and make the handle usable again.
+
+This state machine ensures that a handle is either usable locally or in transit, but never both, preventing a wide class of potential bugs.
+
+### Deserialization (`Deserialize`)
+
+This function reconstructs a `MessagePipeDispatcher` upon its arrival in a new process.
+
+**Key Security Checks:**
+
+1.  **Strict Type Checking**: It validates that it has received exactly one port and zero platform handles, and that the data payload has the exact size of the `SerializedState` struct. Any deviation results in a `nullptr` return, and the message is rejected.
+2.  **Port Validation**: It takes the received `ports::PortName` and uses `node->GetPort()` to resolve it to a valid, live `ports::PortRef`. If the port doesn't exist in the local node (e.g., due to a corrupted message or a logic bug), deserialization fails. This prevents the creation of a dispatcher pointing to an invalid port.
+
+### Quota System (`SetQuota`, `QueryQuota`)
+
+This is the primary defense against denial-of-service attacks where a peer spams a message pipe.
+
+*   **Mechanism**: An application can use `MojoSetQuota` to place a limit on the number of messages in the receive queue, the total memory consumed by those messages, or (most effectively) the number of unacknowledged messages sent by the peer.
+*   **Signaling**: When a quota is exceeded, the `MOJO_HANDLE_SIGNAL_QUOTA_EXCEEDED` signal is asserted on the handle. This allows a well-behaved application to detect the condition and prioritize draining the affected pipe.
+*   **Cross-Process Backpressure**: The `UNREAD_MESSAGE_COUNT` quota is particularly powerful. When set, the dispatcher configures the underlying port to request acknowledgements from its peer at a certain interval (e.g., after every `limit / 2` messages). If the peer doesn't consume messages and return ACKs, the sender's port will eventually become temporarily unwritable, providing true backpressure across the IPC boundary.
+
+## 4. Asynchronous Signaling (`PortObserverThunk`)
+
+The `MessagePipeDispatcher` doesn't poll for state changes. Instead, it registers a `PortObserverThunk` with the `NodeController` for its port. When the `ports` library detects a change (e.g., message arrival, peer closure), it invokes `OnPortStatusChanged` on the observer. This method then acquires the `signal_lock_`, re-evaluates the handle's signal state (`GetHandleSignalsStateNoLock`), and notifies any armed watchers via `watchers_.NotifyState()`. This event-driven model is efficient and fundamental to the `MojoTrap` API.
+
+## 5. Potential Vulnerabilities & Mitigations
+
+*   **Denial of Service**:
+    *   **Threat**: A malicious or buggy peer floods the message pipe, exhausting memory in the receiving process.
+    *   **Mitigation**: The quota system. It is the application's responsibility to set reasonable quotas on pipes connected to less-trusted processes.
+
+*   **Race Conditions**:
+    *   **Threat**: Using a handle on one thread while it is being closed or transferred on another.
+    *   **Mitigation**: The robust locking strategy (`signal_lock_`) combined with the transactional `in_transit_` flag provides strong protection.
+
+*   **Underlying `ports` Library Bugs**:
+    *   **Threat**: The dispatcher's security is fundamentally dependent on the correctness of the `ports` library. A bug in port routing, merging (`Fuse`), or garbage collection could lead to message loss, delivery to the wrong pipe, or memory leaks.
+    *   **Mitigation**: The `MessagePipeDispatcher` itself maintains a very simple and clear responsibility: it manages a single endpoint for a single port. This simple design reduces its own attack surface and relies on the heavily-vetted `ports` library to handle the complex IPC logic.
+
+## 6. Conclusion
+
+The `MessagePipeDispatcher` is a well-designed and security-conscious component. It provides a thread-safe and robust wrapper around the powerful `ports` library. Its main security contributions are its strict lifecycle management (especially during transit), its robust quota system for DoS mitigation, and its clean, event-driven integration with the `ports` library for asynchronous signaling. Its security is, however, inextricably linked to the correctness of the underlying `ports` node implementation.

--- a/security_notes/mojo_node_channel.md
+++ b/security_notes/mojo_node_channel.md
@@ -1,0 +1,83 @@
+# Security Analysis of Mojo Core: The NodeChannel
+
+**File:** `mojo/core/node_channel.cc`
+
+## 1. Overview
+
+The `NodeChannel` is a layer of abstraction built directly on top of the raw `Channel`. While the `Channel` provides a generic, point-to-point byte stream, the `NodeChannel` implements a higher-level control protocol for managing relationships between different "nodes" in the Mojo network. A node typically corresponds to a single process.
+
+The `NodeChannel` is responsible for the IPC *control plane*. Its duties include:
+
+*   **Peer Discovery and Introduction**: Establishing connections between nodes that don't know about each other, often arbitrated by a central "broker" process.
+*   **Invitation Protocol**: A handshake mechanism to securely establish a direct peer-to-peer `Channel`.
+*   **Broker Registration**: Allowing new processes (e.g., sandboxed renderers) to register themselves with the broker process.
+*   **Message Relaying**: Forwarding messages through an intermediary, which is particularly important on platforms like Windows.
+
+From a security standpoint, the `NodeChannel` is responsible for establishing the lines of communication. Flaws in its logic could lead to a process being connected to a malicious peer, a sandbox escape by tricking the broker, or denial of service by disrupting the connection protocol.
+
+## 2. The NodeChannel Protocol
+
+The protocol is defined by a series of message types enumerated in `MessageType`. Each message has a simple `Header` and a corresponding data structure.
+
+### Key Message Types and Their Purpose:
+
+*   **Invitation & Peer Setup**:
+    *   `ACCEPT_INVITEE` / `ACCEPT_INVITATION`: Part of a handshake to establish a new peer-to-peer connection.
+    *   `ACCEPT_PEER`: Finalizes the connection between two peers for a specific named port.
+*   **Broker Interaction**:
+    *   `ADD_BROKER_CLIENT`: A new process asks the broker to be added to the network.
+    *   `BROKER_CLIENT_ADDED`: The broker confirms to a process that a new client has been added, providing a handle to communicate with it.
+    *   `ACCEPT_BROKER_CLIENT`: A client accepts a connection from the broker.
+*   **Introductions**:
+    *   `REQUEST_INTRODUCTION`: A node asks the broker to introduce it to another named node.
+    *   `INTRODUCE`: The broker responds with a handle to the requested node.
+*   **Core Data Exchange**:
+    *   `EVENT_MESSAGE`: Wraps a lower-level `Channel::Message` for transmission. This is the primary data plane message type handled by `NodeChannel`.
+*   **Windows-Specific Relaying**:
+    *   `RELAY_EVENT_MESSAGE`: A request for the broker to forward a message (including handles) to another process.
+    *   `EVENT_MESSAGE_FROM_RELAY`: The message received by the final destination from the relay.
+
+## 3. Security-Critical Operations
+
+### Message Parsing and Dispatch (`OnChannelMessage`)
+
+This is the central function that receives all incoming control messages. It consists of a large `switch` statement that dispatches based on `MessageType`.
+
+**Key Security Aspects:**
+
+1.  **Struct Versioning and Parsing**: The protocol has evolved, leading to multiple versions of some message data structures (e.g., `AcceptInviteeDataV0`, `AcceptInviteeDataV1`). The `GetMessagePayloadMinimumSized` template function is used to safely parse these. It `memset`s the destination struct to zero, `new`s the object to ensure default field initialization, and then `memcpy`s the received data. This pattern is designed to provide backward compatibility.
+    *   **Security Risk**: This is a complex and potentially fragile pattern. A mistake in the size calculation or a mismatch between struct versions could lead to fields being uninitialized or misinterpreted, potentially causing logic bugs. For example, if a new, security-critical field is added, an old client could send a message that leaves this field in its default (and possibly insecure) state.
+
+2.  **Strict Message Validation**: The parser performs numerous checks. It validates that messages have the expected number of handles (e.g., `ADD_BROKER_CLIENT` expects exactly one handle on Windows, zero otherwise). It also checks for minimum payload sizes. Failure in these checks leads to the message being dropped and, in severe cases, the channel being closed and an error being reported via `process_error_callback_`.
+
+3.  **Default-Deny for Unrecognized Messages**: The `switch` statement has a `default` case that ignores any unrecognized message types. This prevents the channel from crashing if it receives a message from a newer version of Chrome with a message type it doesn't understand, which is good for forward-compatibility.
+
+### Handle Management and Relaying
+
+Passing handles between processes is one of the most sensitive operations in IPC.
+
+*   **Broker as a Gateway**: The broker is a highly privileged process that is trusted to mediate connections and pass handles. A sandboxed process sends `ADD_BROKER_CLIENT` with its process handle. The broker uses this to create a communication channel and passes one end back in a `BROKER_CLIENT_ADDED` message. Any flaw in this logic could allow a sandboxed process to get a handle to an unintended resource.
+
+*   **Windows Message Relaying (`RelayEventMessage`)**:
+    *   **Threat Model**: On Windows, it can be difficult to duplicate handles directly between two non-broker processes. The `RelayEventMessage` mechanism uses the broker as an intermediary. The sender serializes a message and sends it to the broker. Critically, the sender *releases* its ownership of the handles in the message, trusting that the broker will receive them, duplicate them for the destination, and forward them.
+    *   **Security Risk**: This is a "fire-and-forget" mechanism that is inherently risky. The code contains a `TODO` acknowledging this: if the broker crashes or never receives the message, the handles are leaked in the sending process. This could lead to resource exhaustion or, in a more complex scenario, use-after-free vulnerabilities if the handle value is later reused by the OS and the original owner still tries to interact with it.
+
+### Capability Negotiation
+
+`NodeChannel` supports a simple capability negotiation system (`kNodeCapabilitySupportsUpgrade`, etc.). When nodes connect, they exchange a bitmask of their capabilities.
+
+*   **Security Implication**: This allows the protocol to evolve gracefully. However, a malicious client could falsely advertise a capability, potentially tricking a peer into using a feature that it doesn't actually support correctly, which might open up new attack vectors. It could also lie and *not* advertise a capability to try to force a peer into a less-secure legacy code path. The code appears to use this only for benign feature selection, but it's a potential area for logical bugs.
+
+## 4. Potential Vulnerabilities
+
+*   **Protocol Logic Bugs**: The state machine for invitations, introductions, and broker registration is complex. A logic flaw could allow an attacker to bypass security checks, connect to an unauthorized peer, or confuse the broker.
+
+*   **Handle Leaks on Windows**: As noted, the `RelayEventMessage` mechanism is a potential source of handle leaks if the broker fails to process the message.
+
+*   **Integer Overflows/Underflows in Parsers**: While the code appears careful, any `memcpy` based on sizes extracted from an untrusted message buffer is a potential site for integer-related vulnerabilities. Rigorous fuzzing is the best defense here.
+
+*   **Abuse of Broker Trust**: A compromised (but still sandboxed) renderer could spam the broker with introduction requests or other messages, potentially leading to denial of service in the browser. The broker must be robust against misbehaving clients.
+
+## 5. Conclusion
+
+The `NodeChannel` provides the essential control plane for Mojo, orchestrating the lifecycle of connections between processes. Its security relies on a strictly validated and carefully implemented message-passing protocol. The primary risks are not in low-level memory corruption (which is the `Channel`'s main concern) but in higher-level **logic bugs** within the connection state machine, particularly around the complex and sensitive operations of handle passing and broker interaction. The Windows-specific message relaying mechanism is a notable area of risk due to its "fire-and-forget" design.

--- a/security_notes/mojo_ports_node.md
+++ b/security_notes/mojo_ports_node.md
@@ -1,0 +1,72 @@
+# Security Analysis of Mojo Core: The `ports` Node
+
+**File:** `mojo/core/ports/node.cc`
+
+## 1. Overview
+
+The `ports::Node` class is the absolute core of the Mojo IPC transport layer. It is a low-level, abstract component responsible for the creation, management, and routing of messages between communication endpoints called "ports." While higher-level constructs like `MessagePipeDispatcher` provide a user-friendly API, the `Node` is the engine that actually implements the message queuing, forwarding, and handle-transfer logic.
+
+A `Node` represents a single participant in the distributed system (typically, a process). All Mojo IPC within a process is managed by its singleton `Node` instance. Understanding its security model is key to understanding the fundamental security guarantees of Mojo itself.
+
+## 2. Core Security Model & Primitives
+
+The security of the `ports` library rests on several foundational concepts:
+
+*   **Strongly-Typed, Unforgeable Names**:
+    *   **`NodeName` & `PortName`**: These are 128-bit, cryptographically random numbers. They serve as unguessable capabilities. A process cannot communicate with a port unless it has been explicitly granted that port's name. This is the primary defense against a malicious process arbitrarily connecting to ports it doesn't own.
+    *   **`RandomNameGenerator`**: This helper class uses `base::RandBytes` to generate names, ensuring a high-quality source of randomness.
+
+*   **Disciplined Locking**: The `Node` manages a collection of `Port` objects, each of which can be accessed by multiple threads. To prevent race conditions and deadlocks, it uses a rigorous two-level locking strategy:
+    *   **`ports_lock_`**: A global lock on the `Node`'s `ports_` map, protecting the collection itself.
+    *   **`Port::lock_`**: A per-port lock protecting the state of an individual `Port`.
+    *   **`PortLocker`**: A sophisticated helper class that acquires locks on multiple ports simultaneously *in a globally-consistent order* (by sorting on port name). This is a critical security feature that makes deadlocks nearly impossible.
+
+*   **Sequenced Control Plane**: All lifecycle operations (e.g., closing a port, transferring a port) are managed by a series of `Event` messages (e.g., `ObserveClosureEvent`, `PortAcceptedEvent`). These control messages are strictly sequenced, and a port will buffer any out-of-order events it receives. This prevents race conditions where, for example, a notification of peer closure could be processed before the final user message arrives.
+
+## 3. Security-Critical Operations
+
+### Port Lifecycle and State Machine
+
+Each `Port` exists in a state machine (`kUninitialized`, `kReceiving`, `kBuffering`, `kProxying`, `kClosed`). The transitions between these states are critical.
+
+*   **`kReceiving`**: The normal, active state.
+*   **`kProxying`**: This is the key to handle transfer. When a port handle is sent in a message, the local port does not move. Instead, it transitions to `kProxying`, and a *new* port is created on the destination node. The local proxy now simply forwards all messages to its new peer (the newly created port).
+*   **Proxy Removal**: This is the most complex part of the protocol. A proxy port is a temporary object that needs to be garbage collected. This is achieved through a handshake:
+    1.  The system sends an `ObserveProxy` event down the chain of ports.
+    2.  When this reaches the ultimate destination, it replies with an `ObserveProxyAck`. This ACK contains the sequence number of the last user message the destination expects to receive.
+    3.  The proxy receives the ACK and enters a "lame duck" mode (`remove_proxy_on_last_message`). It continues forwarding messages until it has seen the last expected message, at which point it removes itself via `TryRemoveProxy`.
+    *   **Security Implication**: This complex protocol, reliant on sequence numbers, ensures that no messages are lost during handle transfer. A bug here could lead to message loss or resource leaks (dangling proxies).
+
+### Event Processing (`AcceptEvent`)
+
+This is the main entry point for all incoming control messages. Its most important security feature is the validation of incoming events.
+
+*   **`IsEventFromPreviousPeer` / `port->IsNextEvent`**: Before processing a sequenced control message, the `Node` validates that the event is from the port's expected peer and that its control sequence number is exactly the one it expects. Any event that fails this check is buffered until its turn comes. This rigorously defends against event-spoofing and race conditions.
+
+### Connection Loss (`LostConnectionToNode`)
+
+This is the "emergency" shutdown path. If a transport-level connection is lost (e.g., a process crashes), this function is called. It iterates through all local ports that were connected to the lost node, marks them as having a `peer_closed`, and notifies their local application owner. It also triggers a broadcast to clean up any proxies in other nodes that might have been pointing to the now-dead node. This provides a robust, albeit "best effort," cleanup in the face of catastrophic failure.
+
+## 4. Potential Vulnerabilities & Mitigations
+
+*   **Protocol Logic Bugs**:
+    *   **Threat**: The state machines for proxy removal and port merging are extremely complex. A logic flaw could lead to resource leaks, message loss, or incorrect routing.
+    *   **Mitigation**: The protocol is designed to be as robust as possible, relying on strict sequencing and explicit acknowledgements. There is no simple mitigation beyond rigorous design, testing, and fuzzing of these complex state transitions.
+
+*   **Deadlocks**:
+    *   **Threat**: Acquiring locks on multiple ports in an inconsistent order.
+    *   **Mitigation**: The `PortLocker` class is the primary and very effective defense against this.
+
+*   **Denial of Service**:
+    *   **Threat**: A malicious peer could send a flood of messages or create complex proxy chains to exhaust memory.
+    *   **Mitigation**: The `ports::Node` itself has limited DoS protection. This responsibility is delegated to the higher-level dispatchers (e.g., `MessagePipeDispatcher`), which implement message-count and memory-usage quotas.
+
+## 5. Conclusion
+
+The `ports::Node` is a masterpiece of low-level IPC engineering. It solves the incredibly difficult problems of routing, queuing, and lifecycle management for a distributed graph of communication endpoints. Its security is not based on simple checks but on the fundamental correctness of its complex protocols. The core security pillars are:
+
+1.  **Unforgeable Names**: Preventing unauthorized connections.
+2.  **Disciplined Locking**: Preventing local data races.
+3.  **Strict Event Sequencing**: Preventing protocol-level race conditions.
+
+A vulnerability in this file would likely be a subtle, high-impact logic bug in one of the complex state machines rather than a simple buffer overflow. The correctness of the `ports` library is the bedrock upon which all of Mojo's security stands.

--- a/security_notes/mojo_shared_buffer_dispatcher.md
+++ b/security_notes/mojo_shared_buffer_dispatcher.md
@@ -1,0 +1,71 @@
+# Security Analysis of Mojo Core: SharedBufferDispatcher
+
+**File:** `mojo/core/shared_buffer_dispatcher.cc`
+
+## 1. Overview
+
+The `SharedBufferDispatcher` is the Mojo `Dispatcher` implementation for shared memory handles (`MojoHandle` of type shared buffer). It acts as a wrapper around the `base::subtle::PlatformSharedMemoryRegion` object, which abstracts the platform-specific details of creating and managing shared memory segments (e.g., POSIX `shm_open`/`mmap`, Windows `CreateFileMapping`/`MapViewOfFile`).
+
+This dispatcher is the concrete implementation for all `Mojo...SharedBuffer...` API calls. Shared memory is a powerful but notoriously dangerous IPC mechanism. Any vulnerability in this dispatcher could lead to information disclosure, memory corruption, or sandbox escapes. Therefore, its design and implementation are critical to the security of the entire Mojo IPC system.
+
+## 2. Core Security Model & State Management
+
+The security model of the `SharedBufferDispatcher` revolves around two key principles: **thread safety** and **strict access control management**, especially during duplication.
+
+*   **State**: The core state of the dispatcher is a single `region_` of type `base::subtle::PlatformSharedMemoryRegion`. This object encapsulates the platform handle(s) and metadata (size, GUID, access mode) for the memory segment.
+
+*   **Locking**: All access to the internal state (`region_` and the `in_transit_` flag) is protected by a `lock_`. This is essential to prevent race conditions where one thread might try to map or close a handle while another thread is serializing it for transit to another process.
+
+*   **Transit State**: The `in_transit_` boolean flag is a crucial part of the lifecycle management. When a shared buffer handle is attached to a message, `BeginTransit()` is called, which sets `in_transit_` to `true`. This effectively locks the dispatcher, preventing any further local operations (like mapping, duplicating, or closing) until the transit is either completed (at which point the dispatcher is destroyed) or canceled. This prevents use-after-free and double-use vulnerabilities.
+
+## 3. Security-Critical Operations
+
+### Deserialization (`SharedBufferDispatcher::Deserialize`)
+
+This static method is a primary security boundary, responsible for reconstructing a `SharedBufferDispatcher` from data received over an untrusted IPC channel.
+
+**Key Security Checks:**
+
+1.  **Payload Size Validation**: It immediately checks if the incoming data size exactly matches `sizeof(SerializedState)`. Any mismatch indicates a malformed message, and deserialization is aborted.
+2.  **Handle Count Validation**: This is a critical platform-dependent check. The dispatcher knows how many platform handles to expect for a given access mode on a given OS. For example, on Linux, a `kWritable` region requires two file descriptors, while a `kReadOnly` or `kUnsafe` one requires only one. The code explicitly checks if `num_platform_handles` matches the expected number. This prevents attackers from confusing the logic by providing an incorrect number of handles.
+3.  **Access Mode Validation**: The `access_mode` field from the serialized data is checked to ensure it's one of the known, valid enum values.
+4.  **GUID and Size Validation**: It ensures the deserialized `num_bytes` is non-zero and that the GUID is a valid `base::UnguessableToken`.
+
+If any of these checks fail, the function returns `nullptr`, and the invalid handles are discarded, preventing a partially-initialized or corrupted dispatcher from entering the system.
+
+### Handle Duplication (`DuplicateBufferHandle`)
+
+This function implements the logic for `MojoDuplicateBufferHandle` and is the most complex and security-sensitive part of the dispatcher. It enforces a strict state machine to prevent dangerous aliasing of writable memory.
+
+**Access Mode State Machine:**
+
+A shared buffer can be in one of three modes: `kReadOnly`, `kWritable`, or `kUnsafe`.
+
+1.  **Requesting a Read-Only Duplicate**:
+    *   If the original is already `kReadOnly`, this is trivial.
+    *   If the original is `kWritable`, it is **permanently demoted to `kReadOnly`** before the duplicate is created. This is a critical security guarantee: once a read-only view of a buffer has been shared, the original owner can no longer write to it, preventing a Time-of-check to time-of-use (TOCTOU) vulnerability where a malicious process could modify the buffer after a trusted process has validated its contents.
+    *   If the original is `kUnsafe`, creating a read-only duplicate is forbidden. This is because an "unsafe" handle implies other writable aliases may exist, making a "safe" read-only view impossible to guarantee.
+
+2.  **Requesting a Writable Duplicate**:
+    *   If the original is `kReadOnly`, this is forbidden. You cannot upgrade a read-only handle.
+    *   If the original is `kWritable`, both the original and the new duplicate are **demoted to `kUnsafe`**. This acknowledges that there are now multiple writable aliases for the same memory region. The `kUnsafe` mode serves as a "taint" flag, indicating that the application is now responsible for memory synchronization and that no "safe" read-only views can ever be created from these handles.
+
+This state machine robustly prevents **aliased writability**, a common source of bugs where multiple actors can write to the same memory without a clear ownership model.
+
+## 4. Potential Vulnerabilities & Mitigations
+
+*   **Race Conditions**:
+    *   **Threat**: Using a handle on one thread while it's being closed, duplicated, or serialized on another.
+    *   **Mitigation**: The `lock_` and the `in_transit_` flag provide strong protection against these scenarios.
+
+*   **Logic Bugs in Duplication State Machine**:
+    *   **Threat**: A flaw in the access mode transitions in `DuplicateBufferHandle` could violate the security invariants (e.g., allowing a read-only and a writable handle to the same buffer to coexist).
+    *   **Mitigation**: The logic is contained entirely within this one function and is designed to be conservative, always failing a request rather than entering an insecure state.
+
+*   **Resource Exhaustion**:
+    *   **Threat**: A malicious process could request a shared buffer of enormous size.
+    *   **Mitigation**: `SharedBufferDispatcher::Create` checks the requested `num_bytes` against a configurable limit (`GetConfiguration().max_shared_memory_num_bytes`), rejecting requests that are too large.
+
+## 5. Conclusion
+
+The `SharedBufferDispatcher` is an excellent example of a security-hardened IPC component. It demonstrates a deep understanding of the risks associated with shared memory by enforcing a strict, conservative state machine for access control. The clear ownership model, thread-safe design, and rigorous validation during deserialization provide multiple layers of defense. The most critical security feature is the access-mode demotion logic in `DuplicateBufferHandle`, which correctly prevents dangerous aliasing of writable memory.

--- a/security_notes/sandbox_policy_linux_bpf_renderer_policy_linux.md
+++ b/security_notes/sandbox_policy_linux_bpf_renderer_policy_linux.md
@@ -1,0 +1,37 @@
+# Security Analysis of `bpf_renderer_policy_linux.cc`
+
+This document provides a security analysis of the `RendererProcessPolicy`, which defines the seccomp-bpf sandbox for the renderer process on Linux. This is arguably the most critical security policy in the browser, as it establishes the narrowest possible kernel attack surface for the process that handles untrusted web content. A vulnerability in this policy could lead to a complete sandbox escape.
+
+## 1. Policy Design: Inheritance and Specificity
+
+The policy follows a robust design pattern of inheriting from a more general `BPFBasePolicy` and then overriding specific system calls.
+
+- **Inheritance:** The policy inherits from `BPFBasePolicy`, which itself builds upon a `BaselinePolicy`. This baseline denies most system calls by default and allows a small, common set needed by nearly all Chrome processes. This "deny-by-default" approach is a fundamental security principle.
+- **Specificity:** The `EvaluateSyscall` method (line 64) in `RendererProcessPolicy` is a `switch` statement that handles only the small number of additional syscalls needed by the renderer. All other syscalls fall through to the more restrictive baseline policy. This ensures that the renderer policy is as minimal as possible.
+
+## 2. Analysis of Allowed System Calls
+
+Each system call allowed by this policy represents a deliberate and security-critical decision.
+
+- **`ioctl`:** This is one of the most dangerous and powerful system calls. Allowing it without restriction would create a massive hole in the sandbox. The policy correctly handles this by delegating to a `RestrictIoctl` function (line 44).
+  - **Security Implication:** This restriction is a **critical security boundary**. The function uses the BPF-DSL to create a whitelist of allowed `ioctl` request codes: `TCGETS` (terminal control), `FIONREAD` (check for readable bytes), and `LOCAL_DMA_BUF_IOCTL_SYNC` (for graphics buffers). Any `ioctl` request that does not match one of these exact codes will crash the process (`CrashSIGSYSIoctl`). This strict whitelist is the only safe way to expose `ioctl` to a sandboxed process. Note that Android has a separate, more permissive `ioctl` policy handled in its baseline.
+
+- **`setrlimit` / `prlimit64`:** These syscalls allow the process to change its own resource limits.
+  - **Justification:** The comments (line 92, 134) explicitly state this is necessary for WebAssembly, which needs to dynamically manage large memory address spaces.
+  - **Security Mitigation:** The risk is mitigated by two factors. First, the kernel prevents a process from raising its `rlim_max` (hard limit) once it has been lowered by the browser at startup. Second, the policy uses `RestrictPrlimit` to further constrain the arguments, preventing the renderer from, for example, changing the limits of other processes.
+
+- **`mremap`:** Allows the process to remap virtual memory regions. This is essential for the V8 garbage collector and other memory-intensive operations. While powerful, it is a necessary part of the modern web platform. Its security relies on the broader ASLR and memory protections of the OS.
+
+- **Other Allowed Syscalls:** The remaining allowed syscalls (`clock_getres`, `fsync`, `pwrite64`, etc.) are generally lower-risk and are required for basic I/O, file operations (on already-opened file descriptors passed from the browser), and getting system information. The policy for `prctl` on ARM architectures is an excellent example of least privilege, allowing only the commands needed to query vector-length information for ARM's Scalable Vector Extensions.
+
+## 3. General Security Posture
+
+- **Principle of Least Privilege:** This policy is a textbook example of the principle of least privilege. It starts with a highly restrictive baseline and only opens up the absolute minimum set of syscalls and `ioctl` commands necessary for a modern web renderer to function.
+- **BPF-DSL for Argument Filtering:** The policy doesn't just allow or deny syscalls; it makes extensive use of the BPF-DSL (e.g., in `RestrictIoctl`, `RestrictPrlimit`) to inspect the *arguments* of those syscalls. This is a powerful technique that allows the sandbox to permit a syscall for a legitimate purpose (e.g., setting a resource limit on itself) while blocking its use for a malicious purpose (e.g., attempting to change the limits of another process).
+
+## Summary of Potential Security Concerns
+
+1.  **Bugs in the Policy Logic:** The primary risk is a logic error in the policy itself. An attacker who finds a legitimate but obscure way to use an allowed syscall with a specific set of arguments could potentially bypass the sandbox. For example, a flaw in the `RestrictIoctl` argument checking could allow a new, dangerous `ioctl` command to be used. **Any change to this file must be considered extremely security-sensitive.**
+2.  **Kernel Vulnerabilities:** The sandbox is designed to reduce the kernel attack surface, not eliminate it. Every allowed syscall is a potential entry point for an attacker to exploit a vulnerability in the Linux kernel itself. The extreme restrictiveness of this policy is the primary mitigation for this risk.
+3.  **Complexity of `mremap` and `prlimit`:** These are powerful memory- and process-management syscalls. While necessary, they represent a significant area of complexity. A subtle interaction between these calls and the V8 engine could potentially lead to a memory corruption vulnerability that could be used to attack the sandbox.
+4.  **Architectural Differences:** The policy contains `#ifdef` blocks for different CPU architectures (x86, ARM, MIPS). It is crucial that these variations are kept in sync and that a syscall allowed on one architecture is carefully considered before being enabled on another.

--- a/security_notes/sandbox_policy_linux_sandbox_seccomp_bpf_linux.md
+++ b/security_notes/sandbox_policy_linux_sandbox_seccomp_bpf_linux.md
@@ -1,0 +1,33 @@
+# Security Analysis of `sandbox_seccomp_bpf_linux.cc`
+
+This document provides a security analysis of the `sandbox_seccomp_bpf_linux.cc` file. This file is a central component of Chromium's sandboxing architecture on Linux. It is responsible for selecting and applying the appropriate seccomp-bpf (secure computing mode with Berkeley Packet Filter) policy for different types of sandboxed processes. This mechanism is the core of the Linux sandbox, restricting the system calls a process can make and thus containing the damage from a compromised renderer or other utility process.
+
+## 1. Sandbox Policy Dispatching
+
+The most critical function of this file is to act as a dispatcher, mapping a process type to a specific, tailored security policy.
+
+- **`PolicyForSandboxType` (line 185):** This function is the heart of the component. It contains a large `switch` statement that takes a `sandbox::mojom::Sandbox` type (e.g., `kRenderer`, `kGpu`, `kNetwork`) and returns the corresponding `BPFBasePolicy` object.
+- **Security Implication:** This is the **primary security decision point** for the Linux sandbox. The integrity of the entire sandboxing model rests on this function correctly assigning the most restrictive policy possible to each process type. A logic error here, such as assigning a permissive policy (e.g., the GPU policy) to a more sensitive process (e.g., the renderer), would create a major vulnerability by granting the process access to system calls it does not need, thereby widening its attack surface.
+
+## 2. Principle of Least Privilege in Policies
+
+The design demonstrates a strong commitment to the principle of least privilege by using a wide variety of highly specialized policies.
+
+- **Specialized Policies:** Instead of a few generic policies, the file includes headers for many specific policies, such as `BpfAudioPolicy`, `BpfCdmPolicy`, and `BpfPrintCompositorPolicy`. This ensures that each process type is granted access to only the narrow set of system calls required for its specific task.
+- **Hardware-Specific GPU Policies:** The `GetGpuProcessSandbox` function (line 125) further refines this principle. On ChromeOS, it dynamically selects a more restrictive policy based on the GPU vendor (AMD, Intel, NVIDIA, etc.). This is a critical security hardening measure, as different GPU drivers require different `ioctl` commands. A generic policy would have to allow the union of all drivers' required syscalls, which would be significantly weaker than a vendor-specific policy. This specialization is a key defense for the highly complex and historically vulnerability-prone GPU process.
+
+## 3. Post-Activation Sandbox Verification
+
+- **`RunSandboxSanityChecks` (line 260):** For high-risk process types like the renderer and GPU, this function is called immediately after the sandbox is enabled. It performs several checks to confirm that the sandbox is active and functioning as expected.
+- **Security Implication:** This is an excellent defense-in-depth measure that acts as a tripwire. The checks are designed to fail in a way that crashes the process if the sandbox is not working correctly. For example, it attempts to call `fchmod` on an invalid file descriptor. Without a sandbox, this would fail with `EBADF`. With the sandbox active, the syscall should be blocked, resulting in `EPERM`. If the check fails, the process is terminated, preventing it from continuing to run in a dangerously unsandboxed state.
+
+## 4. Compile-Time Security Assertions
+
+- **`BUILDFLAG(USE_SECCOMP_BPF)`:** The entire file's functionality is conditionally compiled based on this flag, ensuring that this sandboxing mechanism is only built for supported Linux architectures.
+- **`#error` Directive (line 86):** The code includes a preprocessor `#error` directive that will fail the build if `USE_SECCOMP_BPF` is disabled on an architecture where it is expected to be supported (e.g., x86-64, ARM64). This is a strong security assertion that prevents developers from accidentally creating an insecure build by misconfiguring the build flags.
+
+## Summary of Potential Security Concerns
+
+1.  **Policy Correctness:** The most significant risk lies not in this file, but in the individual policy files it includes (e.g., `bpf_renderer_policy_linux.cc`). A bug in one of those policies—such as allowing a dangerous syscall or an overly broad argument to a permitted syscall—would create a sandbox escape vulnerability. The security of this dispatcher is entirely dependent on the correctness of the policies it dispatches.
+2.  **New Process Types:** When a new sandboxed process type is added to Chromium, it is absolutely critical that it is added to the `PolicyForSandboxType` switch statement with a new, bespoke, and maximally restrictive policy. Forgetting to add an entry or defaulting to a generic policy would be a significant security regression.
+3.  **The `--no-sandbox` Flag:** The `IsSeccompBPFDesired` function (line 156) correctly respects the `--no-sandbox` command-line flag. While essential for debugging, this flag represents a global "off switch" for this critical security layer. Malicious software on a user's machine could attempt to launch Chrome with this flag to bypass the sandbox entirely, though this is an external threat against which the browser itself has limited defenses.

--- a/security_notes/sandbox_policy_win_sandbox_win.cc
+++ b/security_notes/sandbox_policy_win_sandbox_win.cc
@@ -1,0 +1,42 @@
+# Security Analysis of `sandbox_win.cc`
+
+This document provides a security analysis of the `sandbox_win.cc` file. This is the central component of the Chromium sandbox on the Windows platform. It is responsible for orchestrating the creation of sandboxed processes, configuring their security policies using Windows-specific primitives like Integrity Levels, Job Objects, and AppContainers, and applying a wide range of process mitigation policies.
+
+## 1. Core Sandboxing Architecture
+
+The Windows sandbox uses a broker-target model, where the privileged browser process (the broker) sets up a restrictive policy and then spawns the sandboxed child process (the target).
+
+- **`TargetConfig`:** This object, analogous to a seccomp policy on Linux, is used to build the set of restrictions for the target process before it is launched.
+- **Broker Services (`InitBrokerServices`):** The sandbox initializes a global broker service that is responsible for spawning target processes with the policies defined in their `TargetConfig`. This two-process architecture is fundamental to the security model, as it ensures the sandboxed process never has the privileges required to define or weaken its own sandbox.
+- **Integrity Levels (`SetIntegrityLevel`):** The sandbox correctly applies a `LOW` integrity level to sandboxed processes. This is a **critical OS-level security mechanism** that prevents the sandboxed process from writing to most files, registry keys, or other objects on the system, as they typically have a `MEDIUM` integrity level.
+- **Restricted Tokens (`SetTokenLevel`):** The process token is stripped of most of its privileges and groups, leaving it with a minimal set of rights. This follows the principle of least privilege and dramatically reduces the process's capabilities.
+- **Job Objects (`SetJobLevel`):** Processes are placed inside a Job Object, which is used to enforce security constraints like `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (ensuring the sandboxed process dies with the browser) and to set memory limits, preventing resource exhaustion attacks.
+
+## 2. Process Mitigation Policies
+
+This file is responsible for applying a wide range of modern Windows process mitigation policies, which are essential for making vulnerabilities harder to exploit.
+
+- **`SetProcessMitigations` and `SetDelayedProcessMitigations`:** These functions configure policies such as:
+  - **DEP and ASLR:** Fundamental memory protections are enabled (`MITIGATION_DEP`, `MITIGATION_BOTTOM_UP_ASLR`).
+  - **Win32k Lockdown (`MITIGATION_WIN32K_DISABLE`):** For the renderer process, this is arguably the **single most important mitigation**. It severely restricts the process's ability to make system calls into `win32k.sys`, which is the historically most vulnerability-prone part of the Windows kernel. This drastically reduces the kernel attack surface.
+  - **Code Integrity:** The policy enables `MITIGATION_FORCE_MS_SIGNED_BINS` for most process types, which prevents the loading of non-Microsoft-signed DLLs. This is a powerful defense against many third-party software injection techniques. `MITIGATION_DYNAMIC_CODE_DISABLE` is also used for processes like Network and Audio that have no legitimate reason to generate code at runtime.
+
+## 3. AppContainer Sandbox
+
+For modern Windows versions, the sandbox can leverage the even stronger AppContainer technology.
+
+- **`IsAppContainerEnabledForSandbox` and `AddAppContainerProfileToConfig`:** These functions manage the use of AppContainers, which provide isolation based on a fine-grained capability model.
+- **Capabilities (`SetupAppContainerProfile`):** The code carefully defines the specific capabilities granted to each AppContainerized process (e.g., `internetClient`, `privateNetworkClientServer`). This is a strong enforcement of least privilege, ensuring a process only has access to the specific APIs and resources it needs (e.g., the Network service can make network calls, but not access the user's documents).
+- **LPAC (Less Privileged AppContainer):** The use of `SetEnableLowPrivilegeAppContainer(true)` for many process types is a significant security hardening step. LPAC provides an even more restrictive environment than a standard AppContainer, further minimizing the process's capabilities.
+
+## 4. Defense-in-Depth
+
+- **DLL Blocklisting (`kTroublesomeDlls`):** The sandbox maintains a hardcoded list of third-party DLLs that are known to cause instability or security issues. Before a process is launched, the sandbox adds rules to its policy to prevent these specific DLLs from being loaded. This is a pragmatic, real-world defense against a common source of problems.
+- **Handle Inheritance (`CheckDuplicateHandle`):** In non-official builds, the `DuplicateHandle` API is patched to detect when a privileged handle is being passed to a sandboxed process. This is a powerful debugging tool for catching potential sandbox escapes before they are checked in.
+
+## Summary of Potential Security Concerns
+
+1.  **Policy Complexity:** The `GenerateConfigForSandboxedProcess` function is the central point for policy creation and is highly complex, with many conditional checks based on process type, command-line flags, and feature flags. A logic error in this function could result in a process being launched with a weaker-than-intended set of mitigations.
+2.  **Delegate-Induced Vulnerabilities:** The final policy is dependent on the `SandboxDelegate` for a given process. A bug in a delegate's `InitializeConfig` or `DisableDefaultPolicy` implementation could inadvertently weaken the sandbox for that process type.
+3.  **Kernel Vulnerabilities:** The sandbox is designed to limit the attack surface of the Windows kernel, but it cannot eliminate it. Any allowed system call is a potential vector for exploiting a kernel vulnerability. The Win32k lockdown is the primary mitigation, and its strength is paramount.
+4.  **Third-Party Interference:** The existence of the DLL blocklist proves that third-party software injecting itself into Chrome is a persistent threat that can undermine sandbox security. While the blocklist helps, it is reactive by nature.

--- a/security_notes/services_network_cors_cors_url_loader.md
+++ b/security_notes/services_network_cors_cors_url_loader.md
@@ -1,0 +1,42 @@
+# Security Analysis of `cors_url_loader.cc`
+
+This document provides a security analysis of the `CorsURLLoader` class. This class is the workhorse of the Cross-Origin Resource Sharing (CORS) protocol within Chromium's network service. It is responsible for handling a single `fetch()` request, orchestrating the necessary CORS checks, including preflight requests, and ensuring that the response is handled according to the web security model. Its correctness is fundamental to preventing cross-site data leakage.
+
+## 1. CORS Preflight Enforcement
+
+The decision to send a CORS preflight (an `OPTIONS` request) is a critical security function, as it is the mechanism by which a server grants permission for a cross-origin request that could have side effects.
+
+- **`NeedsCorsPreflight` (line 90):** This function is the primary decision point for CORS preflights. It correctly implements the logic from the Fetch standard, triggering a preflight if:
+  - The request uses a method that is not [CORS-safelisted](https://fetch.spec.whatwg.org/#cors-safelisted-method) (e.g., `PUT`, `DELETE`).
+  - The request contains request headers that are not [CORS-safelisted](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).
+- **Security Implication:** This strict adherence to the standard ensures that a cross-origin website cannot arbitrarily send state-changing requests (like a `DELETE` request) to a server without the server's explicit permission via a successful preflight response.
+
+## 2. Private Network Access (PNA) Enforcement
+
+The `CorsURLLoader` is also a key enforcement point for the Private Network Access (PNA) specification, a critical defense against CSRF-like attacks on local network devices.
+
+- **`NeedsPrivateNetworkAccessPreflight` (line 77):** This function checks if a request is targeting a more private IP address space than the initiator (e.g., a public website requesting a resource from a private IP like `192.168.1.1`).
+- **Security Implication:** If a PNA request is detected, it forces a preflight request, even for requests that would normally be considered "simple" by CORS. The server on the local network must then explicitly opt-in to being accessible from the public internet by responding with a specific `Access-Control-Allow-Private-Network: true` header. This is a **vital security mechanism** that prevents malicious websites from using a user's browser as a proxy to attack their router, printer, or other internal network services. The `ShouldIgnorePrivateNetworkAccessErrors` function (line 1388) allows for a "warn-only" mode, which is a security-sensitive configuration that must be handled with care.
+
+## 3. Redirect Handling
+
+Handling HTTP redirects is one of the most complex and security-sensitive parts of the `CorsURLLoader`.
+
+- **`OnReceiveRedirect` (line 711):** This function is called when the network stack receives a 3xx redirect response.
+- **Re-evaluation of CORS:** The implementation correctly re-evaluates the `fetch_cors_flag_` after every redirect. This is critical because a redirect can turn a same-origin request into a cross-origin one, which must then be subjected to a full CORS check.
+- **Tainting:** The `CheckTainted` function (line 699) correctly implements the concept of response tainting across redirects. If a request chain crosses origins, the response is marked as "tainted," which prevents its data from being read by the renderer.
+- **Credential Stripping (`CheckRedirectLocation`):** The logic correctly identifies and rejects redirects to URLs that contain embedded credentials (`user:pass@host`), preventing credentials from being leaked across origins.
+
+## 4. Response Handling and Tainting
+
+After a request completes, the loader is responsible for ensuring that the response is handled according to its tainting mode.
+
+- **`CalculateResponseTainting` (line 195):** This function determines if the final response should be `kBasic` (fully accessible), `kCors` (partially accessible), or `kOpaque` (inaccessible). This is the final enforcement of the Same-Origin Policy.
+- **`response_head->response_type = response_tainting_` (line 687):** The calculated tainting mode is attached to the `URLResponseHead` that is sent back to the renderer. The renderer is then responsible for enforcing this tainting and preventing a script from accessing the body of an opaque response.
+
+## Summary of Potential Security Concerns
+
+1.  **Complexity of Redirect Logic:** This is the highest-risk area. A bug in the state machine that manages redirects—particularly in how the `tainted_` and `fetch_cors_flag_` are managed across a multi-redirect chain—could cause a cross-origin response to be incorrectly treated as same-origin, leading to a universal cross-site scripting (UXSS) vulnerability.
+2.  **Private Network Access (PNA) Bypass:** As a newer security feature, PNA is a complex area. A bug in the IP address space detection, the preflight trigger logic, or the `PreflightController`'s validation of the `Access-Control-Allow-Private-Network` header could create a bypass that would re-enable CSRF attacks against local network devices.
+3.  **Bugs in the `PreflightController`:** The `CorsURLLoader` delegates the complex logic of handling preflight requests and caching their results to the `PreflightController`. Any vulnerability in that component (e.g., incorrectly caching a permissive result) would directly undermine the security of the `CorsURLLoader`.
+4.  **Correct Handling of Opaque Responses:** The security of the "opaque" response tainting relies on the renderer correctly enforcing it. While this class correctly labels the response as opaque, the ultimate security depends on downstream components (in Blink) preventing any data from leaking to the web page.

--- a/security_notes/services_network_cors_cors_url_loader_factory.md
+++ b/security_notes/services_network_cors_cors_url_loader_factory.md
@@ -1,0 +1,41 @@
+# Security Analysis of `cors_url_loader_factory.cc`
+
+This document provides a security analysis of the `CorsURLLoaderFactory` class. This class is a critical security component that sits in the network service. It acts as a factory for creating `URLLoader` instances that are aware of and enforce the Cross-Origin Resource Sharing (CORS) protocol. It is the primary gatekeeper for all `fetch()` requests originating from renderer processes.
+
+## 1. Role as a Security Boundary (Request Validation)
+
+The most important function of this class is `IsValidRequest` (line 596). This method performs a large number of security checks on every incoming `ResourceRequest` *before* any network activity happens. This is the primary defense against a compromised or malicious renderer attempting to craft an invalid or dangerous request.
+
+- **Initiator Lock (`VerifyRequestInitiatorLock`, line 771):**
+  - **Security Implication:** This is arguably the **most critical security check** in the factory. The factory is created with a `request_initiator_origin_lock`. This check ensures that every request created by this factory has a `request_initiator` that matches the lock. This prevents a compromised renderer from using a factory intended for `https://example.com` to forge requests that appear to come from `https://evil.com`. A failure in this logic would allow for universal cross-site request forgery (UXRF). The logic correctly handles the special case for service worker navigations, where the initiator might be different, by validating against the request URL's origin instead.
+
+- **Forbidden Methods and Headers (`IsForbiddenMethod`, `AreRequestHeadersSafe`):**
+  - The factory checks for and rejects requests that use forbidden HTTP methods (like `TRACE` or `TRACK`) or contain unsafe headers. This prevents renderers from constructing requests that could be used to attack or probe servers in unexpected ways.
+
+- **Internal Load Flags (`net::LOAD_...`):**
+  - The code explicitly rejects requests from untrusted renderers that contain internal, privileged load flags (e.g., `LOAD_CAN_USE_SHARED_DICTIONARY`). This is a vital defense-in-depth measure that prevents a compromised renderer from gaining special privileges in the networking stack.
+
+- **Bad Message Reporting (`mojo::ReportBadMessage`):**
+  - Throughout `IsValidRequest`, any failed validation check results in a call to `mojo::ReportBadMessage`. This is a robust security response that terminates the offending renderer process, preventing it from making further malicious requests.
+
+## 2. CORS Protocol Enforcement
+
+If a request is deemed valid, it is then wrapped in a `CorsURLLoader` (line 467), which is responsible for handling the actual CORS protocol logic (e.g., preflight requests).
+
+- **Delegation of Logic:** The factory itself does not implement the details of the CORS preflight and response validation. It correctly delegates this complex logic to the `CorsURLLoader`. This is a good separation of concerns.
+- **`disable_web_security_`:** The factory has a `disable_web_security_` flag. When this is `true`, it bypasses the `CorsURLLoader` and sends the request directly to the underlying network factory. This effectively disables the Same-Origin Policy and CORS for this factory.
+  - **Security Implication:** This is an extremely powerful and dangerous flag. Its use must be restricted to highly trusted contexts, such as testing or specific browser-internal functions. The code comment at line 583 correctly notes that this flag is the reason the factory must handle preflight requests from other `CorsURLLoader`s in certain test scenarios.
+
+## 3. Context and Trust
+
+The factory's behavior is heavily dependent on the context in which it was created.
+
+- **`is_trusted_` flag:** The factory is created with an `is_trusted_` flag. This flag is used to determine whether the factory can handle requests with `trusted_params`. A renderer-created factory will always have `is_trusted_` set to `false`, preventing it from creating requests with elevated privileges.
+- **Origin Access List (`origin_access_list_`):** The factory consults an `OriginAccessList`. This list contains origins that have been granted special privileges (e.g., via extensions or enterprise policy) to bypass normal CORS rules. This is the correct mechanism for handling policy-based exceptions to the SOP.
+
+## Summary of Potential Security Concerns
+
+1.  **Initiator Lock Bypass:** A logic bug in `VerifyRequestInitiatorLock` would be a critical vulnerability, enabling universal cross-site request forgery. The security of all requests handled by this factory depends on this check being perfect.
+2.  **Incorrect `disable_web_security_` Usage:** If a factory with `disable_web_security_` set to `true` were ever exposed to an untrusted process, it would completely break the web security model. The security relies on the browser process correctly managing the lifetime and distribution of these privileged factories.
+3.  **Bugs in `CorsURLLoader`:** The factory delegates the actual CORS protocol enforcement to `CorsURLLoader`. Any vulnerability in that class (e.g., incorrectly parsing preflight response headers, mishandling redirects) would be directly exposed through this factory.
+4.  **Information Leaks in `ResourceRequest`:** The factory assumes that the `ResourceRequest` object it receives from the renderer is well-formed. While it validates many fields, a compromised renderer could still try to leak information by setting unexpected values in less-validated fields, which might then be logged or processed by other parts of the network service. The consistent use of `ReportBadMessage` is the primary mitigation for this.

--- a/security_notes/third_party_blink_renderer_platform_weborigin_security_origin.md
+++ b/security_notes/third_party_blink_renderer_platform_weborigin_security_origin.md
@@ -1,0 +1,45 @@
+# Security Analysis of `security_origin.cc`
+
+This document provides a security analysis of the `SecurityOrigin` class. This class is the C++ implementation of the "origin" concept, which is the absolute cornerstone of the web's security model. The Same-Origin Policy (SOP), enforced using this class, prevents documents and scripts from one origin from accessing resources in another. Its correctness is paramount to the entire security of the browser.
+
+## 1. Origin Creation and Canonicalization
+
+The most critical aspect of this class is how an origin is constructed from a URL, as any error here could lead to an incorrect security decision.
+
+- **`Create(const KURL& url)`:** This is the primary factory method. It delegates to `ShouldTreatAsOpaqueOrigin` to determine if the URL should result in a standard tuple-based origin (scheme, host, port) or a new, unique opaque origin.
+- **Handling of Opaque Origins (`ShouldTreatAsOpaqueOrigin`, line 97):** The logic correctly identifies numerous cases that must result in an opaque origin, which is a key security guarantee. This includes:
+  - Invalid URLs.
+  - URLs with non-standard schemes (with some exceptions for legacy Android behavior).
+  - URLs with schemes registered as "no access" (e.g., internal `chrome-error://` pages).
+- **`data:` URLs:** These are correctly treated as opaque, which is essential to prevent a malicious `data:` URL from inheriting the origin of the page that created it.
+- **`blob:` and `filesystem:` URLs:** The implementation correctly uses the "inner URL" to determine the security origin. This ensures that a blob created by `https://example.com` is part of that origin and cannot be accessed by `https://evil.com`.
+
+## 2. The Same-Origin Policy Implementation
+
+The core SOP logic resides in the comparison functions.
+
+- **`IsSameOriginWith(const SecurityOrigin* other)` (line 550):** This is the strict same-origin check.
+  - It correctly compares the `protocol_`, `host_`, and `port_` of tuple-based origins.
+  - For opaque origins, it correctly compares their internal `nonce_if_opaque_`. This ensures that every opaque origin is unique and is only same-origin with itself, which is the fundamental principle of opaque origins.
+- **`IsSameOriginDomainWith(...)` (line 582):** This function implements the more complex logic that accounts for the legacy `document.domain` API.
+  - It correctly handles the case where two origins can relax their host check if they have both set `document.domain` to the same superdomain value.
+  - The use of `AccessResultDomainDetail` provides fine-grained information for debugging and understanding the result of the check.
+- **`IsSameSiteWith(const SecurityOrigin* other)` (line 641):** This implements the "same-site" check, which is a more relaxed check based on the registrable domain (e.g., `google.com`). This is crucial for modern features like SameSite cookies and Fetch Metadata.
+
+## 3. Privilege Management (Security "God Modes")
+
+The `SecurityOrigin` class has several fields that can grant special privileges, effectively bypassing the SOP. The use of these is highly security sensitive.
+
+- **`universal_access_`:** When set, `CanAccess` and `CanRequest` will **always return true**, granting this origin complete access to any other origin. This is a "god mode" flag that is only used in highly trusted contexts, such as for browser extensions, and must never be exposed to untrusted web content.
+- **`can_load_local_resources_`:** This flag governs whether an origin can access `file://` URLs. The logic correctly defaults this to `true` only for `file://` origins themselves. Granting this privilege to a web origin would allow it to read files from the user's local disk, which would be a critical vulnerability.
+
+## 4. Potentially Trustworthy Origins
+
+- **`IsPotentiallyTrustworthy()` (line 437):** This function is the gatekeeper for many powerful new web platform features (e.g., Service Workers, Web Crypto). It correctly delegates the decision to the centralized `network::IsOriginPotentiallyTrustworthy` function, which enforces the standard definition of a secure context (e.g., `https://`, `wss://`, `localhost`). This ensures a consistent and secure policy for gating access to sensitive APIs.
+
+## Summary of Potential Security Concerns
+
+1.  **Canonicalization Bugs:** The single greatest risk in this file is a bug in the origin canonicalization logic. If an attacker could craft a URL that is parsed into an incorrect security origin (e.g., making it appear same-origin with a victim site), it would lead to a universal cross-site scripting (UXSS) vulnerability, which is one of the most severe browser vulnerabilities. The reliance on the `//url` library for the core parsing logic is a good practice, as this centralizes the canonicalization logic.
+2.  **Misuse of Privilege Flags:** Any accidental or incorrect setting of the `universal_access_` or `can_load_local_resources_` flags would be a critical vulnerability. The security of the system relies on the fact that only highly privileged browser-internal code can ever call the methods that grant these privileges.
+3.  **`document.domain` Complexity:** The logic for handling `document.domain` is inherently complex and a historical source of security bugs across all browsers. While the implementation appears to correctly follow the HTML standard, any change to this logic must be scrutinized with extreme care.
+4.  **Opaque Origin Inheritance (`precursor_origin_`):** Opaque origins can have a "precursor" origin. It is critical that the security properties of this precursor (e.g., its "trustworthiness") are correctly inherited by the opaque origin to prevent a non-trustworthy page from creating an opaque origin that is incorrectly treated as secure.

--- a/security_notes/third_party_webrtc_media_sctp_dcsctp_transport.md
+++ b/security_notes/third_party_webrtc_media_sctp_dcsctp_transport.md
@@ -1,0 +1,35 @@
+# Security Analysis of `dcsctp_transport.cc`
+
+This document provides a security analysis of the `dcsctp_transport.cc` file. This class is the core implementation of the SCTP transport layer in WebRTC, responsible for managing data channels. It acts as a bridge between the secure DTLS transport and the underlying `dcsctp` library, which handles the SCTP protocol logic.
+
+## 1. Security Boundary and Third-Party Dependency
+
+The `DcSctpTransport` class represents a **critical security boundary**. Its primary function is to feed decrypted packets from the `DtlsTransport` into the `dcsctp` third-party library for parsing and processing.
+
+- **`OnTransportReadPacket` (line 716):** This function receives decrypted data from the DTLS layer. It correctly checks that the packet has the `kDtlsDecrypted` flag, ensuring that no unencrypted or unauthenticated data is ever passed to the SCTP parser. This is a fundamental security guarantee.
+- **Dependency on `dcsctp`:** The most significant security consideration for this component is its reliance on the `dcsctp` library. The `DcSctpTransport` itself does minimal parsing; the complex work of parsing SCTP chunks, managing associations, reassembling messages, and handling stream state is all delegated to `dcsctp`.
+- **Security Implication:** The security of WebRTC data channels is fundamentally dependent on the robustness and security of the `dcsctp` library. Any vulnerability in `dcsctp`'s parsing logic (e.g., buffer overflows, integer overflows, logic errors) would be directly exposed to a remote attacker. A malicious peer could craft specific SCTP packets that, once decrypted by DTLS, could exploit such a vulnerability. **A thorough security audit of the `dcsctp` library is essential for the overall security of WebRTC data channels.**
+
+## 2. Resource Management and Denial-of-Service Protection
+
+The transport implements several mechanisms to protect against resource exhaustion attacks from a malicious peer.
+
+- **Max Message Size:**
+  - **`SendData` (line 282):** Before sending a message, the transport checks that its size does not exceed the negotiated `max_message_size`. This prevents a malicious application from trying to send an oversized message that could overwhelm the remote peer's buffers.
+  - **`CreateDcSctpOptions` (line 745):** The underlying `dcsctp` socket is configured with the `max_message_size`, enforcing this limit on both incoming and outgoing messages.
+- **Send Buffer Limits:**
+  - The `dcsctp` socket is configured with a `per_stream_send_queue_limit` and a `max_send_buffer_size`. These limits prevent a single data channel or the entire transport from consuming an unbounded amount of memory for queued outgoing packets, which is a critical defense against DoS attacks.
+  - When the send buffer is full, `SendData` correctly returns a `kErrorResourceExhaustion` error, providing backpressure to the application.
+
+## 3. SCTP Protocol Adherence and Validation
+
+The transport correctly handles SCTP-specific details that are important for security and interoperability.
+
+- **PPID Validation (`OnMessageReceived`, line 489):** When a message is received from the `dcsctp` library, the transport validates its Payload Protocol Identifier (PPID). It uses `ToDataMessageType` to ensure the PPID corresponds to a known WebRTC data channel type (control, string, or binary). Messages with unknown PPIDs are safely discarded. This is a crucial validation step that prevents malformed or unexpected message types from being processed further up the stack.
+- **Empty Message Handling:** The implementation correctly handles the sending of empty messages by using specific PPIDs (`kStringEmpty`, `kBinaryEmpty`) and a single-byte payload, as per RFC 8831. This demonstrates attention to protocol correctness, which is essential for avoiding parsing ambiguities and interoperability issues.
+
+## Summary of Potential Security Concerns
+
+1.  **Vulnerabilities in the `dcsctp` Library:** This is the most significant risk. As a large, complex, third-party C++ library responsible for parsing untrusted data, it is a prime target for memory corruption and logic vulnerabilities. The security of `DcSctpTransport` is inextricably linked to the security of `dcsctp`.
+2.  **State Machine Desynchronization:** A subtle bug could cause the state of the `DcSctpTransport` to become desynchronized from the underlying `DtlsTransport` (e.g., after a DTLS renegotiation). This could lead to a scenario where the transport attempts to send data when the underlying channel is not actually secure or writable, potentially causing data loss or errors. The `OnDtlsTransportState` handler (line 700) attempts to mitigate this by resetting the socket on a DTLS restart.
+3.  **Resource Limit Configuration:** The effectiveness of the DoS protections relies on the `SctpOptions` being configured with reasonable limits. While the defaults are sensible, an application could potentially configure them in an insecure way.

--- a/security_notes/third_party_webrtc_p2p_base_connection.md
+++ b/security_notes/third_party_webrtc_p2p_base_connection.md
@@ -1,0 +1,49 @@
+# Security Analysis of `connection.cc`
+
+This document provides a security analysis of the `connection.cc` file from the WebRTC codebase. The `Connection` class represents a candidate pair and is responsible for managing its state, performing connectivity checks, and handling data transfer. Its security is paramount for the integrity and confidentiality of the peer-to-peer link.
+
+## 1. STUN Connectivity Checks
+
+The core function of a `Connection` is to perform STUN-based connectivity checks (pings) to determine writability and measure RTT.
+
+- **Request/Response Matching:** The `StunRequestManager` (`requests_`) is used to manage outgoing STUN requests and match them with incoming responses using the transaction ID. This is a fundamental mechanism to prevent spoofed responses and ensure the reliability of the connectivity checks.
+
+- **STUN Message Integrity:**
+  - **Outgoing Pings:** Outgoing `STUN_BINDING_REQUEST` messages correctly include the `MESSAGE-INTEGRITY` attribute, signed with the remote candidate's password (line 1916).
+  - **Incoming Responses:** Incoming `STUN_BINDING_RESPONSE` messages are validated using `ValidateMessageIntegrity` with the remote candidate's password (line 549). Any response with an invalid signature is silently discarded.
+  - **Security Implication:** This strict adherence to message integrity validation is the primary defense against off-path attackers attempting to spoof STUN responses to manipulate the connection state.
+
+- **Peer-Reflexive Candidate Discovery:**
+  - `MaybeUpdateLocalCandidate` (line 1763): When a connectivity check succeeds, this function inspects the `XOR-MAPPED-ADDRESS` in the response. If this address doesn't match any known local candidate, it correctly creates a new "peer-reflexive" candidate. This is a standard and essential part of the ICE protocol. The security of this process relies on the validated STUN response.
+
+## 2. Connection State Management
+
+The `Connection` class implements a state machine to track the health of the candidate pair.
+
+- **`UpdateState` (line 1012):** This function is the heart of the state management logic. It periodically checks the connection's health.
+- **`TooManyFailures` and `TooLongWithoutResponse`:** These helper functions define the conditions under which a connection is deemed unreliable (`STATE_WRITE_UNRELIABLE`) or failed (`STATE_WRITE_TIMEOUT`). This logic is crucial for robustness, allowing the ICE agent to quickly abandon a poor connection and switch to a better one.
+- **`dead()` (line 1331):** This function determines if a connection is completely defunct and should be destroyed. The logic, which considers time since last received packet and outstanding pings, is a good security practice to prevent resource exhaustion from dead or zombie connections.
+
+## 3. Google-Specific Protocol Extensions
+
+The `Connection` class implements several non-standard, Google-specific extensions to STUN. These are the most significant areas of security concern.
+
+- **`GOOG_PING`:** A lightweight alternative to `STUN_BINDING_REQUEST`. While it also uses message integrity (`MESSAGE-INTEGRITY-32`), any custom protocol extension increases the attack surface and may have subtle flaws not present in the standardized equivalent.
+
+- **`GOOG_DELTA`:**
+  - `goog_delta_consumer_` and `goog_delta_ack_consumer_`: These callbacks are used to handle a dictionary-based compression scheme over STUN.
+  - **Security Risk:** Compression oracles are a known class of vulnerability. If an attacker can influence the data being compressed and observe the resulting size, they may be able to leak secret information. The security of this feature depends entirely on the implementation of the delta consumer, which is outside this file but represents a significant potential risk.
+
+- **DTLS Piggybacking on STUN:**
+  - `MaybeAddDtlsPiggybackingAttributes` (line 612) and `MaybeHandleDtlsPiggybackingAttributes` (line 645): These functions implement a mechanism to embed DTLS handshake data within STUN connectivity check messages.
+  - **Security Risk:** This is a highly complex and non-standard feature. It intertwines the ICE and DTLS handshakes. A flaw in this logic could:
+    - Allow for manipulation or truncation of DTLS messages.
+    - Create parsing ambiguities that could be exploited.
+    - Interfere with the DTLS state machine, potentially leading to a handshake failure or a compromised connection.
+    This feature significantly increases the attack surface and requires intense scrutiny.
+
+## Summary of Potential Security Concerns
+
+1.  **Complex Custom Extensions:** The `GOOG_DELTA` and DTLS piggybacking features are the most significant security risks. Their complexity and non-standard nature make them prime candidates for implementation bugs, logic flaws, or side-channel attacks (like compression oracles).
+2.  **State Machine Complexity:** The connection state machine is complex. While it appears robust, a subtle bug could lead to a connection being kept alive when it should be dead (resource exhaustion) or killed when it is still viable (denial of service).
+3.  **Information in Logs:** Extensive logging is used. In debug builds or if logs are improperly handled, sensitive information about network configuration could be leaked.

--- a/security_notes/third_party_webrtc_p2p_base_port.md
+++ b/security_notes/third_party_webrtc_p2p_base_port.md
@@ -1,0 +1,47 @@
+# Security Analysis of `port.cc`
+
+This document provides a security analysis of the `port.cc` file in the WebRTC codebase. The `Port` class is a foundational component of the ICE implementation, representing a local endpoint from which ICE candidates are generated and connections are established.
+
+## 1. STUN Message Processing
+
+The `Port` class is responsible for parsing and handling incoming STUN messages, which is a security-critical function.
+
+- **`GetStunMessage` (line 438):** This function serves as the primary entry point for parsing STUN packets.
+  - **Authentication and Integrity:** It correctly enforces the presence of `USERNAME` and `MESSAGE-INTEGRITY` attributes for STUN binding requests. It validates the message integrity using the shared secret (`password_`). Failure to do so results in `STUN_ERROR_UNAUTHORIZED` or `STUN_ERROR_BAD_REQUEST` responses, which aligns with RFC 5389 and is crucial for preventing unauthenticated entities from interacting with the ICE agent.
+  - **Username Parsing:** The `ParseStunUsername` function (line 645) correctly splits the username into local and remote user fragments (ufrags). This is essential for associating the request with the correct ICE session.
+  - **Unknown Attributes:** The function properly handles unknown comprehension-required attributes by sending a `STUN_ERROR_UNKNOWN_ATTRIBUTE` response for requests and discarding responses/indications, as specified by the STUN standard.
+  - **Google-Specific Extensions:** The code handles `GOOG_PING` messages, a non-standard extension. While it also checks for message integrity, any custom protocol extension increases the attack surface and requires careful review.
+
+## 2. Candidate Management and Privacy
+
+A key security function of the `Port` is to generate local candidates while protecting user privacy.
+
+- **`MaybeObfuscateAddress` (line 258):** This function implements a critical privacy feature. When an mDNS responder is available, it replaces the candidate's local IP address with a generated `.local` hostname.
+  - **Benefit:** This prevents the user's actual local IP address from being leaked to the signaling server and the remote peer, mitigating a significant privacy risk.
+  - **Risk:** The security of this feature depends entirely on the correctness and security of the underlying `MdnsResponderInterface` implementation. A vulnerability in the mDNS responder could potentially be exploited.
+
+## 3. ICE Security Mechanisms
+
+The `Port` class implements core ICE mechanisms that are essential for a secure negotiation.
+
+- **`MaybeIceRoleConflict` (line 670):** This function implements the ICE role conflict resolution mechanism. When two peers both act as "controlling," this logic uses the `tiebreaker_` value to determine which peer should switch to the "controlled" role.
+  - This is a critical security mechanism that prevents deadlocks and potential manipulation of the ICE process. The implementation appears to correctly follow the logic outlined in the ICE specification.
+  - It also correctly identifies and handles a loopback scenario where a port receives its own STUN request.
+
+## 4. Network Access Control
+
+The `Port` class includes a defense-in-depth mechanism against network scanning attacks.
+
+- **`MaybeRequestLocalNetworkAccessPermission` (line 996):** Before a socket operation, this function can request permission to access the local network. This is particularly relevant when dealing with candidates that might resolve to private or local IP addresses.
+  - This check provides an important safeguard, preventing malicious web pages from using a compromised renderer process to scan a user's internal network via WebRTC. The effectiveness relies on the `LocalNetworkAccessPermissionFactory` implementation.
+
+## 5. Resource Management
+
+- **`DestroyIfDead` (line 872):** The `Port` class has a timeout mechanism to automatically destroy itself if it remains unused (i.e., has no active connections) for a specific period. This is important for preventing resource leaks and cleaning up stale objects.
+
+## Summary of Potential Security Concerns
+
+1.  **mDNS Responder Security:** The privacy-enhancing address obfuscation feature relies on an mDNS responder. Vulnerabilities in this responder could compromise the privacy feature or introduce other risks.
+2.  **Complexity:** The STUN parsing and ICE state management logic is inherently complex. While it appears to follow the standards, the complexity increases the risk of subtle bugs that could have security implications.
+3.  **Custom Extensions:** The use of `GOOG_PING` adds non-standard functionality that could be a source of vulnerabilities if not implemented perfectly.
+4.  **Downstream Dependencies:** The security of features like Local Network Access depends on the implementation of injected factories (`lna_permission_factory_`), which may vary in different embedding environments.

--- a/security_notes/third_party_webrtc_p2p_base_port_allocator.md
+++ b/security_notes/third_party_webrtc_p2p_base_port_allocator.md
@@ -1,0 +1,39 @@
+# Security Analysis of `port_allocator.cc`
+
+This document provides a security analysis of the `port_allocator.cc` file from the WebRTC codebase. The `PortAllocator` class acts as a factory for `PortAllocatorSession` objects, which are responsible for creating the various types of ports (UDP, TCP, STUN, TURN) used in an ICE session. This file is central to enforcing high-level security and privacy policies for ICE.
+
+## 1. Candidate Sanitization and Privacy
+
+The most critical security function within this file is `PortAllocator::SanitizeCandidate` (line 319). This method is responsible for stripping sensitive information from ICE candidates before they are signaled to a remote peer, which is the primary defense against IP address leakage.
+
+- **mDNS Obfuscation:** The function checks if mDNS obfuscation is enabled. If it is, it sets a flag (`use_hostname_address`) to replace the local IP address in host candidates with a `.local` mDNS hostname. This is a powerful privacy-preserving feature that prevents the actual local IP from being exposed.
+
+- **Related Address Filtering:** The function contains crucial logic to filter the `related_address` from STUN and TURN candidates. The `related_address` typically contains the local IP address of the client. Exposing it would leak information about the user's local network topology. The decision to filter is based on several conditions:
+  - **Disabling Host Candidates:** If host candidates (`CF_HOST`) are disabled via the candidate filter, the allocator will also strip the related address from STUN candidates. This provides a consistent policy: if the application doesn't want to expose host IPs, it shouldn't leak them via STUN candidates either.
+  - **Disabling Adapter Enumeration:** Flags like `PORTALLOCATOR_DISABLE_ADAPTER_ENUMERATION` also trigger the filtering of related addresses, reinforcing the goal of hiding local network details.
+  - **mDNS Obfuscation:** When mDNS obfuscation is active, related addresses are also filtered to ensure the local IP is not leaked through a different channel.
+
+## 2. Candidate Generation Control
+
+The `PortAllocator` provides a mechanism to control which types of ICE candidates are created, which is a fundamental tool for enforcing security policies.
+
+- **`SetCandidateFilter` (line 291):** This function sets the `candidate_filter_`, which can be configured to allow or disallow host, server-reflexive (STUN), and relay (TURN) candidates.
+- **Security Implication:** An application can use this filter to enforce specific data paths. For example, by setting the filter to `CF_RELAY`, an application can ensure that all media traffic is forced through a TURN server. This is a common requirement in enterprise or high-security environments where direct P2P connections are disallowed for policy reasons.
+
+## 3. Secure Configuration
+
+The `PortAllocator` is the central point for configuring STUN and TURN servers.
+
+- **`SetConfiguration` (line 152):** This function takes a list of `RelayServerConfig` objects.
+- **Secure TURN:** The `RelayServerConfig` constructors (lines 35-65) include logic to handle secure protocols. Specifically, if a relay is configured with `PROTO_TCP` and a `secure` flag is set to true, the protocol is automatically upgraded to `PROTO_TLS`. This encourages and simplifies the use of encrypted TURNS, which is critical for protecting the integrity and confidentiality of TURN allocations and traffic.
+
+## 4. Session Pooling and Credential Management
+
+- **Candidate Pooling:** The allocator can pre-allocate and pool `PortAllocatorSession` objects to speed up future ICE negotiations.
+- **`restrict_ice_credentials_change_`:** This flag (set via `set_restrict_ice_credentials_change`, line 133) provides a security safeguard for the pooling mechanism. When true, a pooled session can only be reused if the new ICE credentials match the ones it was created with. This helps prevent logical errors where a session might be inadvertently reused across different security contexts.
+
+## Summary of Potential Security Concerns
+
+1.  **Complexity of Sanitization Logic:** The logic in `SanitizeCandidate` for deciding when to filter related addresses is complex, depending on multiple flags (`candidate_filter_`, `PORTALLOCATOR_DISABLE_ADAPTER_ENUMERATION`, mDNS status). A misconfiguration or a bug in this logic could lead to the unintentional leakage of private IP addresses, undermining user privacy.
+2.  **Reliance on Correct Configuration:** The security of the ICE process heavily relies on the application correctly configuring the `PortAllocator`. An application that fails to set an appropriate candidate filter or provides insecure TURN server details (e.g., TURN over UDP/TCP instead of TLS) could expose users to risk.
+3.  **Information Leakage via New Candidate Types:** The sanitization logic is written to handle known candidate types (host, srflx, prflx, relay). If a new candidate type were introduced in the future, the `SanitizeCandidate` function would need to be updated to handle it correctly, otherwise it could become a new vector for information leakage.

--- a/security_notes/third_party_webrtc_p2p_base_stun_port.md
+++ b/security_notes/third_party_webrtc_p2p_base_stun_port.md
@@ -1,0 +1,33 @@
+# Security Analysis of `stun_port.cc`
+
+This document provides a security analysis of the `stun_port.cc` file, which implements the `StunPort` and its base class `UDPPort`. These classes are responsible for sending STUN (Session Traversal Utilities for NAT) requests to a STUN server to discover a client's public IP address and port, thereby creating a "server-reflexive" (srflx) ICE candidate.
+
+## 1. STUN Server Interaction and Address Resolution
+
+The process of interacting with STUN servers, especially when they are specified by hostname, is a primary security consideration.
+
+- **`ResolveStunAddress` (line 439):** When a STUN server is provided as a hostname (e.g., `stun.example.com`), this function initiates an asynchronous DNS resolution.
+- **`MaybeRequestLocalNetworkAccessPermission` (line 500):** This is the **most critical security control** in this file. Before a STUN request is sent to a resolved IP address, this function is called. It checks if the address is part of the local network and, if so, requests permission before allowing the connection.
+  - **Security Implication:** This mechanism is the primary defense against DNS Rebinding and Server-Side Request Forgery (SSRF) attacks. Without this check, an attacker who controls a DNS server could trick the WebRTC client into sending STUN requests to internal network hosts (e.g., `192.168.1.100`), effectively using the user's browser as a network scanner. The security of the entire `StunPort` heavily relies on the correct and strict implementation of the `LocalNetworkAccessPermissionFactory` provided by the embedding application.
+
+## 2. Server-Reflexive Candidate Creation
+
+Once a STUN binding request is successful, the port creates a srflx candidate. The handling of the information in this candidate is important for privacy.
+
+- **`OnStunBindingRequestSucceeded` (line 534):** This function is called with the `stun_reflected_addr` (the public IP and port) from the STUN response.
+- **Related Address Handling:** The `related_address` of a srflx candidate is the local address of the socket that sent the request. Leaking this address can reveal information about the user's internal network structure. The implementation demonstrates good privacy practices:
+  - It correctly sets the `related_address` to the local socket address.
+  - **`MaybeSetDefaultLocalAddress` (line 517):** In the specific case where the port is bound to the "any" address (`0.0.0.0`) for privacy reasons, this function attempts to replace it with the system's default local IP. If that fails, it correctly empties the related address entirely. This prevents the meaningless `0.0.0.0` from being signaled and ensures the private IP is not leaked if adapter enumeration is disabled.
+
+## 3. Robustness and State Management
+
+The `StunBindingRequest` class (line 62) manages the state of STUN requests, which is important for robustness against network issues and preventing resource leaks.
+
+- **Timeouts and Retries:** The class implements a timeout (`OnTimeout`) and error handling (`OnErrorResponse`) mechanism. It will retry a failed request for a limited duration (`kRetryTimeout`), which makes the process resilient to transient network failures.
+- **Keep-Alives:** The implementation includes a STUN keep-alive mechanism to maintain NAT bindings. The lifetime of these requests is capped (`stun_keepalive_lifetime_`), preventing them from running indefinitely and consuming resources.
+
+## Summary of Potential Security Concerns
+
+1.  **Dependency on Local Network Access Permission:** The entire security model against SSRF and network scanning hinges on the `LocalNetworkAccessPermission` check. Any vulnerability or misconfiguration in the factory that provides this check would directly compromise the security of the `StunPort`.
+2.  **DNS Rebinding:** While mitigated by the permission check, the use of DNS to resolve STUN server hostnames remains the primary attack vector for this component.
+3.  **Information Leakage in Error Events:** The `OnStunBindingOrResolveRequestFailed` function (line 572) creates a `CandidateErrorEvent` that includes the reason for failure. While this is standard and useful for debugging, care must be taken by the application to not expose these detailed error strings directly to untrusted web content, as they could potentially leak information about network conditions or misconfigurations.

--- a/security_notes/third_party_webrtc_p2p_base_turn_port.md
+++ b/security_notes/third_party_webrtc_p2p_base_turn_port.md
@@ -1,0 +1,45 @@
+# Security Analysis of `turn_port.cc`
+
+This document provides a security analysis of the `turn_port.cc` file. This file implements the `TurnPort`, which is responsible for allocating and managing a relayed candidate through a TURN (Traversal Using Relays around NAT) server. The `TurnPort` is a critical component for enabling connectivity when direct P2P connections fail, and its security is essential to prevent misuse of the TURN server and protect the client.
+
+## 1. Authentication and Authorization
+
+The `TurnPort`'s primary security function is to securely authenticate with the TURN server.
+
+- **STUN Authentication:** The implementation correctly uses the STUN long-term credential mechanism.
+  - An initial `Allocate` request is sent, and if the server challenges with a 401 Unauthorized, the `OnAuthChallenge` function (line 1453) correctly parses the `REALM` and `NONCE`.
+  - It then computes a `hash` based on the username, realm, and password, which is used to add a `MESSAGE-INTEGRITY` attribute to subsequent requests (`AddRequestAuthInfo`, line 1169).
+  - **Security Implication:** This is a standard and robust mechanism that prevents unauthorized clients from using the TURN server and protects the integrity of the STUN/TURN messages against tampering by an off-path attacker.
+
+## 2. Protection Against Malicious Servers and Redirection
+
+A key threat model is a malicious or compromised TURN server attempting to attack the client. The `TurnPort` implementation contains several crucial defenses.
+
+- **Alternate Server Redirection (`OnTryAlternate`, line 1490):** The port handles the `STUN_ERROR_TRY_ALTERNATE` response, which instructs the client to use a different server. The security checks in `SetAlternateServer` (line 810) are critical:
+  - **Loopback Address Blocking:** It explicitly blocks any redirection attempt to a loopback address (e.g., `127.0.0.1`). This is a **vital security control** that prevents a malicious server from tricking the client into attacking services running on its own machine.
+  - **Redirection Loop Prevention:** It keeps a record of `attempted_server_addresses_` to prevent infinite redirection loops.
+
+- **Local Network Access Permission (`PrepareAddress`, line 347):** Before connecting to a TURN server (especially one resolved from a hostname), the port calls `MaybeRequestLocalNetworkAccessPermission`.
+  - **Security Implication:** This is the primary defense against DNS Rebinding attacks. If an attacker-controlled DNS server resolves the TURN server's hostname to a private IP address, this check prevents the client from blindly connecting and sending data into the user's local network. The security of this mechanism depends on a correct implementation of `LocalNetworkAccessPermissionFactory` by the browser or application.
+
+- **Disallowed Ports (`AllowedTurnPort`, line 998):** This static method implements a policy that restricts TURN connections to a set of allowed ports (e.g., 80, 443, and unprivileged ports > 1024). This is a defense-in-depth measure that prevents a malicious server from redirecting the client to a sensitive, well-known port on another machine.
+
+## 3. TURN Protocol Security Model
+
+The implementation correctly adheres to the TURN security model, which prevents the relay from being used as an anonymous proxy for attacks.
+
+- **Permissions:** The `TurnPort` creates a `TurnEntry` for each peer it communicates with. This entry is responsible for sending a `CreatePermission` request to the TURN server for the peer's IP address (`TurnEntry::SendCreatePermissionRequest`, line 1803). The TURN server will then only relay traffic to peers for whom a permission exists. This is the fundamental mechanism that prevents an attacker from using the relay to launch attacks against arbitrary third parties.
+
+- **Channel Binding:** For performance, the port can establish a "channel" to a peer, which uses a lightweight header. This is only done after a `CreatePermission` request has been successful, so it does not bypass the core security model.
+
+## 4. `TurnCustomizer` Hook
+
+- **`TurnCustomizerMaybeModifyOutgoingStunMessage` (line 1315):** This function provides a hook for the embedding application to modify STUN messages before they are sent.
+- **Security Risk:** This is a powerful but potentially dangerous feature. A buggy or malicious `TurnCustomizer` could remove or alter security-critical attributes like `MESSAGE-INTEGRITY`, or add attributes that create a security vulnerability. The overall security of the `TurnPort` is therefore dependent on the correctness and trustworthiness of the `TurnCustomizer` implementation, if one is provided.
+
+## Summary of Potential Security Concerns
+
+1.  **Reliance on External Security Checks:** The security of the `TurnPort` against DNS Rebinding and SSRF attacks is entirely dependent on the externally-provided `LocalNetworkAccessPermissionFactory`. A weak or absent implementation of this check would create a major vulnerability.
+2.  **`TurnCustomizer` Risk:** The `TurnCustomizer` hook represents a significant risk, as it allows for the arbitrary modification of security-critical STUN messages. Any application using this feature must ensure its implementation is secure.
+3.  **Malicious TURN Server:** While the client has defenses, a malicious TURN server can still cause denial of service by dropping traffic or refusing to create allocations. Using an encrypted transport (`turns://`) is essential to prevent a man-in-the-middle from intercepting or modifying TURN traffic.
+4.  **Complexity:** The TURN state machine (allocating, authenticating, refreshing, creating permissions, binding channels) is complex. The implementation in `TurnPort` and `TurnEntry` has many states and asynchronous operations, which increases the potential for subtle bugs.

--- a/security_notes/third_party_webrtc_p2p_client_basic_port_allocator.md
+++ b/security_notes/third_party_webrtc_p2p_client_basic_port_allocator.md
@@ -1,0 +1,41 @@
+# Security Analysis of `basic_port_allocator.cc`
+
+This document provides a security analysis of the `basic_port_allocator.cc` file, which contains the primary implementation of the `PortAllocator` interface in WebRTC. This class is the engine that drives ICE candidate gathering. It translates high-level configuration into the creation of UDP, TCP, STUN, and TURN ports on specific network interfaces. Its primary security role is to enforce policies about which networks to use and what types of candidates to generate, directly impacting user privacy and network security.
+
+## 1. Network Selection and Privacy
+
+The allocator's method of selecting which network interfaces to use is a critical privacy and security function.
+
+- **`GetNetworks()` (line 665):** This is the central function for enumerating and filtering usable networks.
+- **Adapter Enumeration Control:** The allocator correctly respects the `PORTALLOCATOR_DISABLE_ADAPTER_ENUMERATION` flag. When this flag is set, instead of enumerating all local network interfaces (which could leak information), it wisely defaults to using the "any" address (`0.0.0.0` or `::`). This is a crucial privacy feature that prevents the IP addresses of non-default network interfaces (e.g., VPNs, virtual adapters) from being exposed.
+- **Network Filtering:** The implementation provides multiple layers of filtering to control which networks are used:
+    - `PORTALLOCATOR_DISABLE_LINK_LOCAL_NETWORKS`: Prevents the use of link-local IPv6 addresses.
+    - `network_ignore_mask_`: Allows for a bitmask to ignore specific adapter types.
+    - `vpn_preference_`: Provides explicit control over whether to use, ignore, or allow VPN networks.
+- **IPv6 Network Limiting:** `SelectIPv6Networks` (line 755) implements logic to cap the number of IPv6 networks used for candidate gathering. While primarily for performance and to avoid flooding the remote peer with candidates, this also has a security benefit of limiting the attack surface.
+
+## 2. Candidate Filtering and Exposure
+
+A core security responsibility of the allocator is to control what information is exposed in the generated candidates.
+
+- **`IsAllowedByCandidateFilter` (line 132):** This helper function is the gatekeeper that enforces the high-level candidate filter (`CF_HOST`, `CF_REFLEXIVE`, `CF_RELAY`). It correctly prevents candidates from being signaled if they don't match the application's policy.
+- **`CandidatePairable` (line 1135):** This function contains a subtle but important privacy mechanism. When adapter enumeration is disabled, a host candidate is generated on the "any" address. This candidate is *not* signaled (as per the filter), but `CandidatePairable` allows it to be used for *outgoing* connectivity checks. This allows the connection to proceed without leaking the machine's default IP address in the signaled candidate, striking a good balance between privacy and functionality.
+
+## 3. Secure Port Allocation Strategy
+
+The `AllocationSequence` class orchestrates the creation of different port types in a structured way.
+
+- **Phased Allocation:** Ports are created in phases (UDP/STUN, then Relay, then TCP). This structured approach helps manage the allocation process.
+- **Secure Defaults and Controls:** The allocation logic contains several security-conscious controls:
+  - It respects `PORTALLOCATOR_DISABLE_UDP_RELAY`, providing a mechanism to disallow unencrypted TURN-over-UDP connections.
+  - In `CreateTurnPort` (line 1586), it validates that the address family of the TURN server is compatible with the local network's address family, preventing misconfigured or potentially malicious cross-family connection attempts.
+
+## 4. Port Pruning Policies
+
+- **`turn_port_prune_policy_`:** The allocator supports policies like `KEEP_FIRST_READY` and `PRUNE_BASED_ON_PRIORITY`. These policies reduce the number of active TURN ports by culling redundant or lower-priority ones. While primarily an efficiency measure, this also reduces the overall network attack surface by minimizing the number of open connections to TURN servers.
+
+## Summary of Potential Security Concerns
+
+1.  **Configuration Complexity:** The ultimate security posture of the `BasicPortAllocator` is critically dependent on a complex combination of flags (`PORTALLOCATOR_*` flags), the candidate filter, and network masks. A misconfiguration by the embedding application could easily lead to unintended information exposure (e.g., leaking a VPN IP) or connectivity failures. The security relies on the developer configuring it correctly.
+2.  **Logical Nuances:** The interaction between different flags creates subtle but important behaviors. For example, allowing a public host candidate to be signaled when only `CF_REFLEXIVE` is set is a reasonable exception, but it highlights the complexity of the filtering logic. Any modification to this code requires a deep understanding of these interactions to avoid introducing privacy or security regressions.
+3.  **Regathering Logic:** The process for handling network changes (`OnNetworksChanged`, `Regather`) is complex. A bug in this logic could cause a failure to establish a connection on a new, valid network or, conversely, a failure to properly tear down candidates on a network that is no longer available, leading to connection delays or failures.

--- a/security_notes/third_party_webrtc_p2p_dtls_dtls_transport.md
+++ b/security_notes/third_party_webrtc_p2p_dtls_dtls_transport.md
@@ -1,0 +1,45 @@
+# Security Analysis of `dtls_transport.cc`
+
+This document provides a security analysis of the `dtls_transport.cc` file. This component is responsible for orchestrating the DTLS handshake over an established ICE connection. Its primary role is to secure the peer-to-peer channel, providing confidentiality and integrity for application data (SCTP) and deriving the keys for SRTP media encryption.
+
+## 1. Core DTLS Security Mechanisms
+
+The security of the entire WebRTC data and media stream relies on the correct implementation of the DTLS handshake and its associated security mechanisms.
+
+- **Certificate Fingerprint Verification:**
+  - **`SetRemoteFingerprint` (line 340):** This is the **most critical security function** in the `DtlsTransport`. It takes the fingerprint of the remote peer's certificate, which is received securely through the application's signaling channel (e.g., from an SDP offer/answer).
+  - This fingerprint is then passed to the underlying `SSLStreamAdapter` (`dtls_->SetPeerCertificateDigest`). The `SSLStreamAdapter` is responsible for verifying that the certificate presented by the peer during the DTLS handshake matches this pre-shared fingerprint.
+  - **Security Implication:** This fingerprint verification is the cornerstone of WebRTC's security model, preventing man-in-the-middle (MITM) attacks. A successful connection implies that the client is talking to the peer it intended to, as authenticated by the signaling channel. Any bug that bypasses this check would be a critical vulnerability.
+
+- **SRTP Key Derivation:**
+  - **`ExportSrtpKeyingMaterial` (line 424):** After a successful DTLS handshake, this function is called to extract keying material from the DTLS session, as specified by RFC 5764 (DTLS-SRTP).
+  - **Security Implication:** These exported keys are used to configure the SRTP context for encrypting and authenticating all media packets. The confidentiality and integrity of the audio/video stream are entirely dependent on the secrecy and correctness of this exported material. The security relies on the underlying TLS library's implementation of the key exporter.
+
+## 2. Handshake and State Management
+
+The `DtlsTransport` implements a state machine (`DtlsTransportState`) to manage the handshake process.
+
+- **Role Negotiation (`SetDtlsRole`, line 272):** The transport correctly establishes whether it will act as the DTLS client or server. This role is typically determined by the ICE controlling role to avoid handshake collisions. The implementation correctly prevents the role from being changed after the handshake has begun.
+
+- **Handshake Initiation (`MaybeStartDtls`, line 933):** The DTLS handshake is initiated only after the underlying ICE transport becomes writable. This is a robust design that waits for a confirmed data path before attempting the handshake.
+
+- **Packet Demultiplexing (`OnReadPacket`, line 761):** This function is the entry point for all packets from the ICE layer. It performs the crucial task of demultiplexing incoming traffic:
+  - It uses `IsDtlsPacket` to identify DTLS handshake records and forwards them to the `SSLStreamAdapter`.
+  - After the handshake is complete, it uses `IsRtpPacket` to identify SRTP packets and passes them up to the application layer.
+  - **Security Implication:** A bug in this demultiplexing logic could cause packets to be misinterpreted (e.g., treating an application data packet as a DTLS handshake message), which could lead to state machine confusion and potential vulnerabilities.
+
+## 3. DTLS-in-STUN (Piggybacking)
+
+- **`dtls_in_stun_` flag:** This enables an experimental, non-standard feature (`WebRTC-IceHandshakeDtls`) where DTLS handshake data is fragmented and carried within STUN messages.
+- **`DtlsStunPiggybackController`:** This class manages the complex logic of capturing, fragmenting, and reassembling the DTLS messages that are piggybacked on STUN.
+- **Security Risk:** This is a **significant area of security concern** due to its complexity and non-standard nature.
+  - It intertwines the state of the ICE transport with the DTLS handshake in a novel way.
+  - It implements custom logic for retransmitting handshake messages (`PeriodicRetransmitDtlsPacketUntilDtlsConnected`, line 1098), bypassing the standard DTLS retransmission timer.
+  - Any bug in the fragmentation, reassembly, or state management of the piggyback controller could lead to a corrupted or failed handshake, creating a denial-of-service vulnerability or, in a worst-case scenario, a vulnerability that could be exploited to compromise the handshake. This feature dramatically increases the attack surface of the transport layer.
+
+## Summary of Potential Security Concerns
+
+1.  **DTLS-in-STUN Complexity:** This experimental feature is the most significant risk. Its custom logic for fragmenting and retransmitting DTLS messages is a prime candidate for subtle bugs that could break the security of the DTLS handshake.
+2.  **Implementation of `SSLStreamAdapter`:** The `DtlsTransport` is a wrapper around the `SSLStreamAdapter`. The ultimate security of the DTLS handshake, including protection against known TLS vulnerabilities (e.g., Heartbleed, POODLE), depends on the correctness and robustness of the underlying `SSLStreamAdapter` and the TLS library it uses (e.g., BoringSSL).
+3.  **State Machine Integrity:** The state machine (`dtls_state_`) must be managed perfectly. A bug that causes a state mismatch between the `DtlsTransport` and the underlying `SSLStreamAdapter` could lead to security issues, such as attempting to send data over an insecure channel.
+4.  **Certificate Management:** The security relies on the application providing a valid `RTCCertificate`. Weak keys or a compromised certificate would undermine the entire security model.

--- a/security_notes/third_party_webrtc_pc_ice_transport.md
+++ b/security_notes/third_party_webrtc_pc_ice_transport.md
@@ -1,0 +1,25 @@
+# Security Analysis of `ice_transport.cc`
+
+This document provides a security analysis of `pc/ice_transport.cc` and its associated header file.
+
+## 1. Role and Functionality
+
+The `IceTransportWithPointer` class is not a primary implementation of the ICE protocol. Instead, it serves as a **thread-safe wrapper** and **lifetime manager** for an `IceTransportInternal` object. The actual implementation of the ICE logic is found in other classes, most notably `P2PTransportChannel`, which implements the `IceTransportInternal` interface.
+
+The main functionality of this class is:
+- To hold a raw pointer (`internal_`) to the concrete `IceTransportInternal` implementation.
+- To ensure that this pointer is cleared on the correct thread (`creator_thread_`) before the object is destroyed, preventing use-after-free bugs.
+
+## 2. Security Analysis
+
+The security implications of this file are not related to the ICE protocol itself, but rather to C++ object lifetime and thread safety, which are fundamental to preventing memory corruption vulnerabilities.
+
+- **Thread Safety:** The class uses `RTC_DCHECK_RUN_ON` to enforce that its methods are called on the expected thread (`creator_thread_`). This is a critical security measure to prevent race conditions where one thread might be destroying the `internal_` pointer while another thread is trying to access it. A failure in this thread-safety model could lead to a classic use-after-free vulnerability.
+
+- **Destructor Logic:** The destructor (line 18) contains a crucial check. It asserts that if the `internal_` pointer is still valid when the destructor is called, the destructor must be running on the `creator_thread_`. This enforces the contract that the object's owner is responsible for calling `Clear()` on the correct thread before releasing its last reference. This strict lifecycle management is essential for preventing memory-related security bugs.
+
+## Summary of Potential Security Concerns
+
+1.  **Incorrect Lifetime Management:** The primary security risk associated with this class is a bug in its usage by a consumer. If a consumer of `IceTransportWithPointer` fails to call `Clear()` on the correct thread before the object is destroyed on a different thread, it could lead to a use-after-free vulnerability when the destructor's `RTC_DCHECK` is triggered in a release build (where `DCHECK`s are compiled out). The class itself is implemented defensively, but its security relies on correct usage.
+
+In essence, the security of `ice_transport.cc` is about robust C++ programming practices rather than high-level protocol security. The core protocol security concerns reside in the implementation it wraps, such as `P2PTransportChannel`.

--- a/security_notes/v8_src_sandbox_code_pointer.md
+++ b/security_notes/v8_src_sandbox_code_pointer.md
@@ -1,0 +1,32 @@
+# Security Analysis of `code-pointer.h`
+
+This document provides a security analysis of the `code-pointer.h` file. This header defines the high-level API for reading and writing pointers to executable code entry points within the V8 sandbox. This is a critical security mechanism designed to prevent control-flow hijacking attacks, such as ROP/JOP, by an attacker who has compromised the V8 heap.
+
+## 1. Core Security Design: The Code Pointer Table
+
+This API is the front-end for a specialized indirection mechanism, the `CodePointerTable`, which is analogous to the `ExternalPointerTable` but used exclusively for pointers to executable code.
+
+- **The Problem:** V8 heap objects often need to store pointers to the native machine code that implements them (e.g., a `JSFunction` object points to its compiled entry point). If these raw code pointers were stored directly on the heap, an attacker with a memory corruption vulnerability could overwrite them to point to shellcode or a ROP gadget, achieving arbitrary code execution.
+
+- **The Solution:** Instead of storing a raw code pointer, V8 objects store a `CodePointerHandle` (a 32-bit value) in their fields. This handle is an index into the trusted, out-of-line `CodePointerTable`.
+
+## 2. Secure Read/Write Barrier for Code Pointers
+
+The functions defined in this header constitute the secure read/write barrier that all V8 code must use to interact with code pointers.
+
+- **`WriteCodeEntrypointViaCodePointerField` (line 23):** This function is the write barrier. When V8 needs to associate a heap object with a code entry point, it calls this function. This function does **not** write the raw `Address value` (the entry point) to the object field. Instead, it stores the entry point in the `CodePointerTable` and writes the corresponding handle back into the object's field.
+
+- **`ReadCodeEntrypointViaCodePointerField` (line 17):** This is the read barrier. When V8 needs to call a function, it uses this function to retrieve the code entry point. It reads the handle from the object field and uses it to look up the real entry point in the `CodePointerTable`.
+
+- **Security Implication:** This indirection is the **central defense against control-flow hijacking**. An attacker who can corrupt the `CodePointerHandle` on the heap can only make it point to a different, *valid* entry within the `CodePointerTable`. They cannot make it point to arbitrary addresses (like shellcode in an `ArrayBuffer`). This severely constrains the attacker's ability to divert control flow, effectively defeating many standard exploitation techniques.
+
+## 3. Entry Point Tagging
+
+- **`CodeEntrypointTag`:** The read and write functions both take a `tag` parameter. This is analogous to the `ExternalPointerTag` and provides a form of type safety for code pointers. It ensures that a handle intended for a specific type of function entry point cannot be used to retrieve a pointer to a different, incompatible type of entry point. This helps mitigate more advanced attacks that might try to cause type confusion at the code level.
+
+## Summary of Potential Security Concerns
+
+1.  **Correctness of the `CodePointerTable`:** The security of this entire mechanism depends on the `CodePointerTable` being implemented securely. A bug in the table's allocation, garbage collection, or access control could undermine the entire model. For example, if the table were writable by sandboxed code, an attacker could simply overwrite a table entry with a pointer to their shellcode.
+2.  **Completeness of Adoption:** Every single code pointer stored on the V8 heap must be migrated to use this API. Any legacy raw code pointer is a direct vector for a control-flow hijack and a sandbox escape.
+3.  **JIT Code Generation:** The process of generating new JIT code and registering it with the `CodePointerTable` is a highly security-sensitive operation. A vulnerability in the JIT compiler that allows an attacker to write malicious code *and* get a valid handle to it in the table would bypass this defense. The security relies on the JIT code itself being generated in a read-only + execute memory region that is not writable from the sandboxed heap.
+4.  **Side-Channel Attacks (Spectre):** While this mechanism is designed to defeat classic memory corruption attacks, it does not, by itself, prevent Spectre-style attacks where an attacker might speculatively execute code by manipulating a `CodePointerHandle` to mis-train the branch predictor. This is a separate class of vulnerability mitigated by other defenses.

--- a/security_notes/v8_src_sandbox_external_pointer.md
+++ b/security_notes/v8_src_sandbox_external_pointer.md
@@ -1,0 +1,37 @@
+# Security Analysis of `external-pointer.h`
+
+This document provides a security analysis of the `external-pointer.h` file. This file, along with its inline implementation, defines the crucial "field-level" API for interacting with the V8 Sandbox's External Pointer Table (EPT). It provides the low-level functions that V8 objects use to read and write pointers to external objects, acting as the primary read/write barrier that enforces the sandbox's guarantees.
+
+## 1. Abstraction and Encapsulation
+
+The file defines the `ExternalPointerMember<tag>` class template, which is a key abstraction for managing external pointer fields within V8 objects.
+
+- **`ExternalPointerMember` (line 14):** This class encapsulates the `ExternalPointer_t` handle, which is the 32-bit index into the EPT. It is designed to be a member variable inside a V8 heap object, replacing what would have been a raw `Address` pointer.
+- **Security Implication:** This abstraction is critical for security. By forcing all interactions with the external pointer field to go through the `load` and `store` methods of this class, it ensures that no code can accidentally (or maliciously) treat the 32-bit handle as a real pointer. It centralizes the logic for interacting with the EPT, reducing the chance of bugs.
+
+## 2. Secure Read/Write Barrier
+
+The free functions defined in this file constitute the read/write barrier for external pointers. Their correct implementation is non-negotiable for the security of the sandbox.
+
+- **`WriteExternalPointerField` (line 69):** This function is called when a V8 object needs to store a pointer to an external object.
+  - It does **not** write the raw `Address value` into the field.
+  - Instead, it calls `isolate->GetExternalPointerTableFor(tag).AllocateAndInitializeEntry(...)`. This allocates a *new* entry in the EPT, stores the raw pointer there, and returns a 32-bit handle.
+  - It then writes this **handle**, not the raw pointer, into the object's field.
+  - **Security Implication:** This is the core write barrier. It ensures that raw pointers to external objects are never stored directly on the V8 heap where they could be corrupted by an attacker.
+
+- **`ReadExternalPointerField` (line 56):** This function is the corresponding read barrier.
+  - It reads the 32-bit `ExternalPointerHandle` from the object's field.
+  - It then uses this handle to look up the real pointer in the EPT: `isolate->GetExternalPointerTableFor(tag_range).Get(handle, tag_range)`.
+  - The `Get` method within the EPT performs the crucial tag check before returning the raw pointer.
+  - **Security Implication:** This is the core read barrier. It ensures that every access to an external pointer is mediated by the EPT. An attacker who has corrupted a handle on the heap can only force a read from a different slot *within the table*. The tag check within the `Get` operation provides a second layer of defense, ensuring that the corrupted access will fail if the tag of the new target slot does not match what the code expects, preventing type confusion attacks.
+
+## 3. Lazy Initialization
+
+- **`InitLazyExternalPointerField` (line 34):** This function initializes a field with a null handle. The design comment at line 53 notes that the read path (`ReadExternalPointerField`) can safely handle these lazy fields because the null handle is guaranteed to resolve to a `kNullAddress`. This is an important detail for ensuring that uninitialized fields don't pose a security risk.
+
+## Summary of Potential Security Concerns
+
+1.  **Incorrect Usage of the API:** The security of this model relies on all V8 code consistently using these read/write barrier functions. Any code that manually reads the 32-bit handle and attempts to use it without going through the EPT, or any code that accidentally stores a raw pointer in a field, would create a hole in the sandbox. The use of the `ExternalPointerMember` class template is designed to make this difficult, but the risk remains if the API is misused.
+2.  **Tag Mismatches:** The security of the read barrier depends on the calling code providing the correct `ExternalPointerTagRange`. If code is written that uses too broad a range, or the wrong tag entirely, it could defeat the type-safety mechanism and allow a type confusion attack.
+3.  **Compiler Optimizations:** A sufficiently advanced compiler could, in theory, attempt to optimize away the read/write barrier calls if it can prove that they are redundant in a certain context. It is critical that the implementation of these functions (particularly their atomic nature and interaction with the `volatile` EPT entries) is robust enough to prevent the compiler from making optimizations that would break the security guarantees.
+4.  **Bugs in the EPT Implementation:** These functions are the "front door" to the `ExternalPointerTable`. Any vulnerability in the table itself (e.g., in the allocation, compaction, or GC logic) would be directly exploitable through these API calls.

--- a/security_notes/v8_src_sandbox_external_pointer_table.md
+++ b/security_notes/v8_src_sandbox_external_pointer_table.md
@@ -1,0 +1,37 @@
+# Security Analysis of `external-pointer-table.h`
+
+This document provides a security analysis of the `external-pointer-table.h` file, which defines the interface for the V8 Sandbox's External Pointer Table (EPT). This component is a cornerstone of the sandbox's security, providing a mechanism to safely reference memory outside the V8 heap from within the sandboxed environment.
+
+## 1. Core Security Design: Indirection as a Primitive
+
+The fundamental security principle of the EPT is **indirection**. Instead of storing raw, 64-bit pointers on the V8 heap (which, if corrupted, could point anywhere in the process's memory), objects on the heap store a 32-bit `ExternalPointerHandle`. This handle is effectively an index into the EPT.
+
+- **Security Implication:** This design is the **primary defense against sandbox escapes via pointer corruption**. An attacker who gains arbitrary read/write within the V8 heap can overwrite a handle, but they can only make it point to another entry *within the EPT*. They cannot use it to craft a pointer to an arbitrary address (e.g., the stack, GOT/PLT, or other sensitive data structures). At worst, a corrupted handle will cause a type confusion between two different kinds of external objects, or it will point to an invalid entry, both of which are significantly harder to exploit for a full sandbox escape than a direct arbitrary read/write primitive.
+
+## 2. Type Safety via Tagging
+
+The EPT enforces a form of type safety for external pointers, which is a critical second layer of defense.
+
+- **`ExternalPointerTag`:** When a pointer is stored in the table (`Set`), it is "tagged" by being OR'd with a type-specific `ExternalPointerTag`. When the pointer is retrieved (`Get`), it is untagged.
+- **`GetExternalPointer(ExternalPointerTagRange tag_range)`:** The `Get` operation requires the caller to specify the expected tag (or a range of valid tags). The implementation checks that the tag stored in the entry matches the expected tag.
+- **Security Implication:** This tagging mechanism prevents an attacker from using a corrupted handle to cause a type confusion that would be useful for an exploit. For example, if an attacker corrupts a handle that is supposed to point to a `JSArrayBuffer` backing store and makes it point to an entry for a `JSFunction`'s native code object, the tag check will fail upon access. This will result in an invalid pointer being returned, leading to a safe crash rather than allowing the attacker to execute arbitrary code or read/write out of bounds.
+
+## 3. Temporal Safety via Garbage Collection
+
+The EPT is tightly integrated with V8's garbage collector to prevent use-after-free vulnerabilities involving external objects.
+
+- **Marking Bit:** Each entry contains a marking bit. When an object on the V8 heap is marked as live during a GC cycle, the `Mark` function (line 412) is called for its corresponding EPT entry. This sets the marking bit in the table.
+- **Sweeping:** After marking is complete, the `SweepAndCompact` function iterates through the table. Any entry that was not marked is considered dead and is reclaimed (added to a freelist). This ensures that entries for garbage objects are invalidated, preventing dangling pointers.
+- **`ManagedResource`:** This class provides a mechanism for external C++ objects to tie their lifetime to the EPT. When a `ManagedResource` is destroyed, its destructor is expected to call `ZapExternalPointerTableEntry`, which invalidates the corresponding entry in the table, preventing it from becoming a dangling pointer.
+
+## 4. Compaction and Memory Management
+
+- **`EvacuateAndSweepAndCompact`:** The table supports compaction, which involves moving live entries to fill the gaps left by dead ones. This is a highly complex process that requires updating all corresponding `ExternalPointerHandle` values on the V8 heap.
+- **Security Implication:** The complexity of the compaction algorithm is a potential source of vulnerabilities. A bug in this logic—for example, failing to update a handle on the heap after its entry has been moved, or an error in the freelist management—could lead to a handle pointing to the wrong entry, resulting in a type confusion or a dangling pointer that an attacker could exploit.
+
+## Summary of Potential Security Concerns
+
+1.  **Completeness:** The security of the EPT model depends on the **absolute absence** of raw, non-sandboxed pointers to external objects on the V8 heap. Any single raw pointer that is overlooked and not migrated to this system represents a potential hole in the sandbox.
+2.  **Compaction Logic:** The memory compaction algorithm is extremely complex. A bug in this code could lead to state corruption within the EPT, potentially creating exploitable dangling pointers or type confusions.
+3.  **Tagging Discipline:** The security of the type-tagging system relies on developers correctly assigning unique and appropriate tags to different types of external pointers. Reusing tags or failing to check the tag on access could undermine the type safety guarantees.
+4.  **Lifetime of `ManagedResource`:** The `ManagedResource` pattern relies on the C++ object's destructor correctly zapping its EPT entry. A bug where an external object is freed without its entry being zapped would create a classic dangling pointer vulnerability.

--- a/security_notes/v8_src_sandbox_sandbox.md
+++ b/security_notes/v8_src_sandbox_sandbox.md
@@ -1,0 +1,37 @@
+# Security Analysis of `sandbox.h`
+
+This document provides a security analysis of the `v8/src/sandbox/sandbox.h` header file. This file defines the public interface and high-level architecture of the V8 Sandbox, a critical security feature designed to contain memory corruption vulnerabilities within the V8 JavaScript engine.
+
+## 1. High-Level Architecture and Goal
+
+The V8 Sandbox represents a fundamental shift in V8's security posture, moving beyond simple process-level isolation to create a memory-safe cage *within* the renderer process itself.
+
+- **Goal:** The primary goal is to mitigate the impact of memory corruption vulnerabilities inside V8. The design assumes an attacker can achieve arbitrary read/write *within* the sandbox's memory region but aims to prevent them from using this capability to corrupt other memory in the process and achieve code execution.
+- **Virtual Address Space Reservation:** The core of the design is the reservation of a massive, contiguous region of virtual memory (ideally 1TB on 64-bit systems). All V8 heap objects, ArrayBuffer backing stores, and WASM memory are intended to be allocated within this region.
+
+## 2. Key Architectural Security Mechanisms
+
+The `sandbox.h` file and its comments describe several key security mechanisms that form the foundation of the sandbox:
+
+- **Sandboxed Pointers:** The comments explicitly state that objects within the sandbox reference each other using offsets from the sandbox base, not raw pointers. This is the **core security guarantee of the V8 Sandbox**. If an attacker corrupts a pointer on the heap, they can only change the offset, meaning the corrupted pointer will still resolve to an address *within* the sandbox. This prevents an attacker from redirecting a corrupted pointer to target sensitive memory outside the sandbox, such as the stack, GOT/PLT tables, or other modules.
+
+- **Guard Regions:** The ideal sandbox layout described in the comments includes large (32GB) guard regions at the beginning and end of the sandbox reservation. This is a classic and powerful defense against linear buffer overflow/underflow attacks. An exploit that simply overflows a buffer on the heap will hit an unmapped guard page and crash the process safely, rather than corrupting adjacent memory.
+
+- **SMI (Small Integer) Mitigation:** The `smi_address_range_is_inaccessible()` function indicates a defense against Smi-to-HeapObject confusion bugs. The sandbox attempts to make the first 4GB of the address space inaccessible. This prevents a common bug class where a 32-bit Smi value is misinterpreted as a pointer and dereferenced, which would otherwise allow an attacker to read/write from a low, often predictable, memory address.
+
+- **External Pointer Sandboxing:** The design overview mentions that external objects are referenced via an index into a trusted table. This is another critical security boundary. Instead of storing a raw pointer on the V8 heap (which could be corrupted to point anywhere), objects store an index. The code that dereferences this index is responsible for validating it against the table. This prevents an attacker from corrupting a pointer to an external object and turning it into an arbitrary read/write primitive outside the sandbox.
+
+## 3. Security Tradeoffs and Fallbacks
+
+- **Partially-Reserved Sandbox:** The code explicitly acknowledges a fallback mode where the full virtual address space reservation is not possible (`is_partially_reserved()`). In this mode, the sandbox is smaller and, crucially, lacks the hardware-enforced guard regions. The comments correctly note that this weakens the security properties, as unrelated memory could be mapped within the sandbox's logical address space. This is a pragmatic tradeoff for resource-constrained systems but represents a less secure configuration.
+
+## 4. Interface with the Embedder
+
+- **`page_allocator()`:** The sandbox exposes a custom `PageAllocator`. This is the designated and secure way for the embedder (Chromium) to allocate memory for large objects like `ArrayBuffer` backing stores *inside* the sandbox. This is a critical architectural feature that ensures these large, often attacker-controlled, data buffers are also contained by the sandbox's memory protections.
+
+## Summary of Potential Security Concerns
+
+1.  **Completeness of Pointer Sandboxing:** The entire security model relies on the complete and correct replacement of all raw pointers on the V8 heap with sandboxed pointers or external pointer table indices. Any single instance of a raw pointer being stored on the heap would represent a "hole" in the sandbox, potentially allowing a full escape.
+2.  **Security of the External Pointer Table:** This table is a highly privileged piece of data. Any vulnerability in its management (e.g., a use-after-free on a table entry, an integer overflow in index calculation, or a type confusion in the object it points to) could be leveraged by an attacker to escape the sandbox.
+3.  **JIT Code:** The security of Just-In-Time (JIT) compiled code is a major challenge for this model. While not detailed in this file, the JIT code must be located outside the sandbox (in a read-only + execute region), and all interactions between the sandboxed heap and this JIT code must be handled with extreme care to prevent an attacker from corrupting a function pointer or return address.
+4.  **Hardware and OS Dependencies:** The effectiveness of the sandbox's virtual memory reservations and guard regions depends on the underlying OS and hardware memory management unit (MMU). A bug in the OS kernel's memory management could potentially undermine the sandbox's foundation.


### PR DESCRIPTION
… in `security_notes/third_party_webrtc_p2p_base_p2p_transport_channel.md`.

I will now move on to the next topic in my continuous security analysis: Chromium's custom memory allocator, PartitionAlloc. I will start by searching for the relevant files.

I have selected the PartitionAlloc Thread Cache as the next topic for my continuous security analysis.

I have reviewed the existing security notes and found that while there is analysis on the general PartitionAlloc system, there are no specific notes on its thread cache mechanism. I will proceed with my analysis.

The results clearly show the core implementation is in `base/allocator/partition_allocator/src/partition_alloc/thread_cache.cc` and its corresponding header. I am now ready to analyze these files.

I have analyzed the PartitionAlloc thread cache implementation in `thread_cache.h` and `thread_cache.cc` and have created the corresponding security notes. This completes the analysis for this component.

I have selected the PartitionAlloc Page Allocator as the next topic for my continuous security analysis.

I have reviewed the existing security notes and confirmed that there is no existing analysis of the PartitionAlloc page allocator. I will proceed with my research.

The results clearly show the core implementation is in `base/allocator/partition_allocator/src/partition_alloc/page_allocator.cc`. I am now ready to analyze this file.

I have analyzed the PartitionAlloc page allocator in `page_allocator.cc` and have created the corresponding security notes. This completes the analysis for this component.

I have selected the Mojo IPC framework as the next topic for my continuous security analysis.

I have reviewed the existing notes and found several on Mojo, including one for the `channel.cc` component. I will proceed with my analysis with the goal of improving or expanding upon the existing documentation.

Found and read `mojo/core/channel.cc`, which appears to be the core implementation of the Mojo channel.

Analyzed `mojo/core/channel.cc` and created the corresponding security note in `security_notes/mojo_channel.md`.

Analyzed `mojo/core/node_channel.cc` and created the corresponding security note in `security_notes/mojo_node_channel.md`.

Analyzed `mojo/core/core.cc` and created the corresponding security note in `security_notes/mojo_core.md`.

Analyzed `mojo/core/shared_buffer_dispatcher.cc` and created the corresponding security note in `security_notes/mojo_shared_buffer_dispatcher.md`.

Analyzed `mojo/core/message_pipe_dispatcher.cc` and created the corresponding security note in `security_notes/mojo_message_pipe_dispatcher.md`.

Analyzed `mojo/core/data_pipe_producer_dispatcher.cc` and created the corresponding security note in `security_notes/mojo_data_pipe_producer_dispatcher.md`.

Analyzed `mojo/core/data_pipe_consumer_dispatcher.cc` and created the corresponding security note in `security_notes/mojo_data_pipe_consumer_dispatcher.md`.

Analyzed `mojo/core/ports/node.cc` and created the corresponding security note in `security_notes/mojo_ports_node.md`.